### PR TITLE
fix: bump MSRV from 1.86 to 1.88 for let chains syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable, "1.86"]
+        toolchain: [stable, "1.88"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MSRV** — Bumped minimum supported Rust version from 1.86 to 1.88 to allow stable `let` chains syntax. ([#6](https://github.com/orreryworks/orrery/issues/6))
+
 ## [0.1.0] - 2026-02-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.88"
 authors = ["Foad Nosrati Habibi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/orreryworks/orrery"


### PR DESCRIPTION
## Summary

Bump the minimum supported Rust version from 1.86 to 1.88. The codebase uses `let` chains (`if cond && let Pat = expr`), which were stabilized in Rust 1.88, causing CI to fail on the 1.86 MSRV toolchain with `error[E0658]`.

Updates:
- Workspace `rust-version` in `Cargo.toml`
- CI test matrix in `.github/workflows/ci.yml`
- `CHANGELOG.md` with an unreleased entry

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #6 
