### PR TITLE
fix: anchor activation boxes to relation positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Component default label displays full qualified path instead of component name ([#4](https://github.com/orreryworks/orrery/issues/4)). Refactored `Id` to split into `name` and `namespace`, so components without an explicit `as "..."` label now show only the final path segment.
+- Activation box starts at next relation instead of preceding relation ([#11](https://github.com/orreryworks/orrery/issues/11)). Activation boxes now anchor to the last relation position rather than the current Y cursor, so they visually start at the triggering message and end at the last message within the block.
 
 ### Changed
 

--- a/crates/orrery/src/layout/engines/basic/sequence.rs
+++ b/crates/orrery/src/layout/engines/basic/sequence.rs
@@ -245,14 +245,14 @@ impl Engine {
     ///
     /// # Algorithm
     /// 1. Iterate through ordered events sequentially
-    /// 2. For `SequenceEvent::Relation`: Create Message at current Y position, update fragment bounds if inside a fragment, then advance Y
-    /// 3. For `SequenceEvent::Activate`: Create ActivationTiming with current Y position, push to participant's stack
-    /// 4. For `SequenceEvent::Deactivate`: Pop activation, convert to ActivationBox with precise bounds
+    /// 2. For `SequenceEvent::Relation`: Create Message at current Y position, update fragment bounds if inside a fragment, record last relation Y, then advance Y
+    /// 3. For `SequenceEvent::Activate`: Create ActivationTiming at last relation Y position (aligning with the triggering message), push to participant's stack
+    /// 4. For `SequenceEvent::Deactivate`: Pop activation, convert to ActivationBox ending at last relation Y position
     /// 5. For `SequenceEvent::FragmentStart`: Create FragmentTiming and push to fragment stack
     /// 6. For `SequenceEvent::FragmentSectionStart`: Start new section in current fragment
     /// 7. For `SequenceEvent::FragmentSectionEnd`: End current section in current fragment
     /// 8. For `SequenceEvent::FragmentEnd`: Pop fragment, convert to Fragment with final bounds
-    /// 9. For `SequenceEvent::Note`: Create positioned Note at current Y, update fragment bounds if inside a fragment, then advance Y by note height
+    /// 9. For `SequenceEvent::Note`: Create positioned Note at current Y, then advance Y by note height
     ///
     /// # Parameters
     /// * `graph` - The sequence diagram graph containing ordered events
@@ -282,6 +282,8 @@ impl Engine {
 
         // Calculate initial Y position using same calculation as messages
         let mut current_y = self.top_margin + participants_height + self.message_spacing;
+        // Track the Y position of the last placed relation (before spacing advance).
+        let mut last_relation_y = current_y;
 
         for event in graph.events() {
             match event {
@@ -305,6 +307,7 @@ impl Engine {
                         fragment_timing.update_x(source_x, target_x);
                     }
 
+                    last_relation_y = current_y;
                     current_y += self.message_spacing;
                 }
                 SequenceEvent::Activate(activate) => {
@@ -315,10 +318,9 @@ impl Engine {
                         .map(|stack| stack.len() as u32)
                         .unwrap_or(0);
 
-                    // Create new ActivationTiming with current Y position
                     let new_timing = ActivationTiming::new(
                         node_id,
-                        current_y,
+                        last_relation_y,
                         nesting_level,
                         Rc::clone(activate.definition()),
                     );
@@ -333,11 +335,8 @@ impl Engine {
                     // Pop the most recent activation for this node
                     if let Some(node_stack) = activation_stack.get_mut(node_id) {
                         if let Some(completed_timing) = node_stack.pop() {
-                            // Convert to ActivationBox using last message position as end
-                            // Subtract message_spacing because current_y is at deactivate event position,
-                            // but we want activation box to end at the last message position
-                            let activation_box = completed_timing
-                                .to_activation_box(current_y - self.message_spacing);
+                            let activation_box =
+                                completed_timing.to_activation_box(last_relation_y);
                             activation_boxes.push(activation_box);
                         }
 

--- a/examples/embedded_diagrams.orr
+++ b/examples/embedded_diagrams.orr
@@ -104,10 +104,12 @@ outer as "Outer System": Service embed diagram sequence {
         ledger: Rectangle[fill_color="#e0f0e0"];
 
         charge_svc -> [stroke=[color="steelblue"]] fraud_check: "Evaluate risk";
-        fraud_check -> [stroke=[color="seagreen", style="dashed"]] charge_svc: "Score";
+        activate fraud_check {
+            fraud_check -> [stroke=[color="seagreen", style="dashed"]] charge_svc: "Score";
+        };
 
-        activate charge_svc {
-            charge_svc -> [stroke=[color="steelblue"]] ledger: "Debit";
+        charge_svc -> [stroke=[color="steelblue"]] ledger: "Debit";
+        activate ledger {
             ledger -> [stroke=[color="seagreen", style="dashed"]] charge_svc: "Confirmation";
         };
     };

--- a/examples/sequence_activation.orr
+++ b/examples/sequence_activation.orr
@@ -28,42 +28,40 @@ db as "Database": Store;
 
 // --- Block Form with Deep Nesting ---
 
-activate client {
-    client -> @RequestArrow api: "POST /checkout";
+client -> @RequestArrow api: "POST /checkout";
 
-    activate api {
-        api -> @RequestArrow auth: "Verify session";
+activate api {
+    api -> @RequestArrow auth: "Verify session";
 
-        activate auth {
-            auth -> @RequestArrow db: "SELECT session";
+    activate auth {
+        auth -> @RequestArrow db: "SELECT session";
 
-            activate db {
-                db -> db: "Validate TTL";
-                db -> @ResponseArrow auth: "Session valid";
-            };
-
-            auth -> @ResponseArrow api: "Token refreshed";
+        activate db {
+            db -> db: "Validate TTL";
+            db -> @ResponseArrow auth: "Session valid";
         };
 
-        api -> @RequestArrow db: "INSERT order";
-        db -> @ResponseArrow api: "Order ID";
-        api -> @ResponseArrow client: "201 Created";
+        auth -> @ResponseArrow api: "Token refreshed";
     };
+
+    api -> @RequestArrow db: "INSERT order";
+    db -> @ResponseArrow api: "Order ID";
+    api -> @ResponseArrow client: "201 Created";
 };
 
 // --- Stacked Activation (Same Participant) ---
 
+client -> @RequestArrow api: "POST /payment";
 activate api {
-    client -> @RequestArrow api: "POST /payment";
     api -> @RequestArrow db: "Check balance";
     db -> @ResponseArrow api: "Balance OK";
 
+    api -> @RequestArrow auth: "Fraud check";
     activate api {
-        api -> @RequestArrow auth: "Fraud check";
         auth -> @ResponseArrow api: "Cleared";
 
+        api -> @RequestArrow db: "INSERT transaction";
         activate api {
-            api -> @RequestArrow db: "INSERT transaction";
             db -> @ResponseArrow api: "Transaction ID";
         };
     };
@@ -73,9 +71,7 @@ activate api {
 
 // --- Explicit Statements ---
 
-activate client;
 client -> @RequestArrow api: "Start export job";
-deactivate client;
 
 activate api;
 api -> @RequestArrow db: "SELECT * FROM records";
@@ -88,32 +84,32 @@ deactivate api;
 
 // --- Mixed: Explicit Outer + Block Inner ---
 
-activate client;
 client -> @RequestArrow api: "DELETE /account";
 
-activate @CriticalActivation api {
-    api -> @RequestArrow auth: "Revoke tokens";
+activate @CriticalActivation api;
+api -> @RequestArrow auth: "Revoke tokens";
+
+activate auth {
     auth -> @ResponseArrow api: "Revoked";
-
-    activate @CriticalActivation db {
-        api -> @RequestArrow db: "DELETE cascade";
-        db -> @ResponseArrow api: "Purged";
-    };
-
-    api -> @ResponseArrow client: "Account deleted";
 };
 
-deactivate client;
+api -> @RequestArrow db: "DELETE cascade";
+activate @CriticalActivation db {
+    db -> @ResponseArrow api: "Purged";
+};
+
+api -> @ResponseArrow client: "Account deleted";
+deactivate api;
 
 // --- Custom Activation Types ---
 
-activate @HighlightActivation api {
-    api -> @RequestArrow db: "ANALYZE tables";
+api -> @RequestArrow db: "ANALYZE tables";
+activate @HighlightActivation db {
     db -> @ResponseArrow api: "Statistics updated";
 };
 
+auth -> @RequestArrow db: "Rotate encryption keys";
 // Anonymous TypeSpec
-activate @Activate[fill_color="rgba(255,240,200,0.4)", stroke=[color="orange"]] auth {
-    auth -> @RequestArrow db: "Rotate encryption keys";
+activate @Activate[fill_color="rgba(255,240,200,0.4)", stroke=[color="orange"]] db {
     db -> @ResponseArrow auth: "Keys rotated";
 };

--- a/examples/styling.orr
+++ b/examples/styling.orr
@@ -78,8 +78,8 @@ note @Note[on=[server], background_color="rgba(255, 255, 200, 0.8)", stroke=[col
 
 // --- Styled Activation ---
 
-activate @Activate[fill_color="rgba(70, 130, 180, 0.15)", stroke=[color="steelblue", width=2.0]] server {
-    server -> [stroke=RoundCapStroke, text=HighlightText] store: "Round cap + join, highlighted text";
+server -> [stroke=RoundCapStroke, text=HighlightText] store: "Round cap + join, highlighted text";
+activate @Activate[fill_color="rgba(70, 130, 180, 0.15)", stroke=[color="steelblue", width=2.0]] store {
     store -> @DashedArrow server: "Response";
 };
 

--- a/examples/type_system.orr
+++ b/examples/type_system.orr
@@ -76,8 +76,8 @@ primary_db -> @ResponseArrow[stroke=[color="green"]] api: "Result set";
 
 // --- Custom Activation Type ---
 
-activate @CriticalActivation api {
-    api -> @UrgentRequest primary_db: "UPDATE session.last_active";
+api -> @UrgentRequest primary_db: "UPDATE session.last_active";
+activate @CriticalActivation primary_db {
     primary_db -> @ResponseArrow api: "Ack";
 };
 


### PR DESCRIPTION
## Summary

Activation boxes in sequence diagrams started at the next relation after the `activate` event instead of the preceding relation that triggered the activation. This PR introduces a `last_relation_y` tracking variable in `process_events()` so both `Activate` and `Deactivate` anchor box boundaries to relation positions. Notes between relations no longer affect activation box extents.

Examples updated to place triggering relations before `activate` blocks.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Other: Examples

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #11 