### PR TITLE
feat: add fragment Y-advancement sizing for sequence diagram layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fragment layout now accounts for vertical space consumed by the operation label header, section title guards, and bottom padding, preventing overlaps with subsequent elements. ([#36](https://github.com/orreryworks/orrery/issues/36))
+
 ### Fixed
 
 - Component default label displays full qualified path instead of component name ([#4](https://github.com/orreryworks/orrery/issues/4)). Refactored `Id` to split into `name` and `namespace`, so components without an explicit `as "..."` label now show only the final path segment.

--- a/crates/orrery-core/src/draw/fragment.rs
+++ b/crates/orrery-core/src/draw/fragment.rs
@@ -62,89 +62,131 @@ pub struct FragmentDefinition {
 }
 
 impl FragmentDefinition {
-    /// Creates a new FragmentDefinition with default values
+    /// Creates a new FragmentDefinition with default values.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Sets the background color
+    /// Sets the background color.
     pub fn set_background_color(&mut self, color: Option<Color>) {
         self.background_color = color;
     }
 
-    /// Gets the operation label text definition
-    pub fn operation_label_text(&self) -> &Rc<TextDefinition> {
-        &self.operation_label_text_definition
-    }
-
-    /// Gets the section title text definition
-    pub fn section_title_text(&self) -> &Rc<TextDefinition> {
-        &self.section_title_text_definition
-    }
-
-    /// Set operation label text definition using Rc.
+    /// Sets the operation label text definition.
     pub fn set_operation_label_text(&mut self, text: Rc<TextDefinition>) {
         self.operation_label_text_definition = text;
     }
 
-    /// Set section title text definition using Rc.
+    /// Sets the section title text definition.
     pub fn set_section_title_text(&mut self, text: Rc<TextDefinition>) {
         self.section_title_text_definition = text;
     }
 
-    /// Set border stroke definition using Rc.
+    /// Sets the border stroke definition.
     pub fn set_border_stroke(&mut self, stroke: Rc<StrokeDefinition>) {
         self.border_stroke = stroke;
     }
 
-    /// Set separator stroke definition using Rc.
+    /// Sets the separator stroke definition.
     pub fn set_separator_stroke(&mut self, stroke: Rc<StrokeDefinition>) {
         self.separator_stroke = stroke;
     }
 
-    /// Sets the content padding
+    /// Sets the content padding.
     pub fn set_content_padding(&mut self, padding: Insets) {
         self.content_padding = padding;
     }
 
-    /// Sets the bounds padding
+    /// Sets the bounds padding.
     pub fn set_bounds_padding(&mut self, padding: Insets) {
         self.bounds_padding = padding;
     }
 
-    /// Gets the border stroke definition
-    pub fn border_stroke(&self) -> &Rc<StrokeDefinition> {
-        &self.border_stroke
-    }
-
-    /// Gets the background color
-    fn background_color(&self) -> Option<&Color> {
-        self.background_color.as_ref()
-    }
-
-    /// Gets the separator stroke definition
-    pub fn separator_stroke(&self) -> &Rc<StrokeDefinition> {
-        &self.separator_stroke
-    }
-
-    /// Gets the content padding
-    fn content_padding(&self) -> Insets {
-        self.content_padding
-    }
-
-    /// Gets the bounds padding
-    fn bounds_padding(&self) -> Insets {
-        self.bounds_padding
-    }
-
-    /// Sets the pentagon fill color
+    /// Sets the pentagon fill color.
     pub fn set_pentagon_fill_color(&mut self, color: Color) {
         self.pentagon_fill_color = color;
     }
 
-    /// Gets the pentagon fill color
+    /// Gets the border stroke definition.
+    pub fn border_stroke(&self) -> &Rc<StrokeDefinition> {
+        &self.border_stroke
+    }
+
+    /// Gets the background color.
+    fn background_color(&self) -> Option<&Color> {
+        self.background_color.as_ref()
+    }
+
+    /// Gets the separator stroke definition.
+    pub fn separator_stroke(&self) -> &Rc<StrokeDefinition> {
+        &self.separator_stroke
+    }
+
+    /// Gets the operation label text definition.
+    pub fn operation_label_text(&self) -> &Rc<TextDefinition> {
+        &self.operation_label_text_definition
+    }
+
+    /// Gets the section title text definition.
+    pub fn section_title_text(&self) -> &Rc<TextDefinition> {
+        &self.section_title_text_definition
+    }
+
+    /// Gets the content padding.
+    fn content_padding(&self) -> Insets {
+        self.content_padding
+    }
+
+    /// Gets the bounds padding.
+    fn bounds_padding(&self) -> Insets {
+        self.bounds_padding
+    }
+
+    /// Gets the pentagon fill color.
     pub fn pentagon_fill_color(&self) -> &Color {
         &self.pentagon_fill_color
+    }
+
+    /// Returns the size of the fragment's header.
+    ///
+    /// # Arguments
+    ///
+    /// * `operation` - The operation type string (e.g., "alt", "loop").
+    pub fn header_size(&self, operation: &str) -> Size {
+        let text = Text::new(&self.operation_label_text_definition, operation);
+        let text_size = text.calculate_size();
+        let triangle_width = Self::triangle_width(text_size);
+        Size::new(text_size.width() + triangle_width, text_size.height())
+    }
+
+    /// Returns the size of a section's header.
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - The section title, if present.
+    pub fn section_header_size(&self, title: Option<&str>) -> Size {
+        match title {
+            Some(title) => {
+                let formatted = format!("[{}]", title);
+                let text = Text::new(&self.section_title_text_definition, &formatted);
+                text.calculate_size().add_padding(self.content_padding)
+            }
+            None => Size::default(),
+        }
+    }
+
+    /// Returns the bottom bounds padding.
+    pub fn bottom_padding(&self) -> f32 {
+        self.bounds_padding.bottom()
+    }
+
+    /// Calculates the triangle width for the pentagon tab.
+    ///
+    /// The width is clamped between 1/4 and 1/2 of the content height,
+    /// with a maximum of 10px.
+    fn triangle_width(content_size: Size) -> f32 {
+        let height = content_size.height();
+        10.0f32.min(height / 2.0).max(height / 4.0)
     }
 
     /// Creates an SVG path element for a pentagonal tab (rectangle with triangular point on right).
@@ -161,10 +203,7 @@ impl FragmentDefinition {
     fn create_pentagon_path(&self, content_bounds: Bounds) -> (svg_element::Path, Bounds) {
         let top_left = content_bounds.min_point();
 
-        // Calculate triangle width as half the height for proper proportions
-        let triangle_width = 10.0f32
-            .min(content_bounds.height() / 2.0)
-            .max(content_bounds.height() / 4.0);
+        let triangle_width = Self::triangle_width(content_bounds.to_size());
 
         // Create path: rectangle + triangle point
         // L x+w+t,y - start top-right with triangle
@@ -226,8 +265,8 @@ impl Default for FragmentDefinition {
 
             pentagon_fill_color: Color::new("white").expect("Invalid color"),
 
-            content_padding: Insets::new(8.0, 8.0, 8.0, 8.0),
-            bounds_padding: Insets::new(20.0, 20.0, 20.0, 20.0),
+            content_padding: Insets::new(0.0, 0.0, 0.0, 8.0),
+            bounds_padding: Insets::new(0.0, 20.0, 0.0, 20.0),
         }
     }
 }
@@ -379,16 +418,16 @@ impl Drawable for Fragment {
         output.merge(op_text_output);
 
         // 4. Render section separators and titles
-        let mut current_y = pentagon_bounds.max_y();
+        let mut current_y = top_left.y();
 
         for (i, section) in self.sections().iter().enumerate() {
             // Skip separator for the first section
             if i > 0 {
                 // Draw separator line
                 let separator = svg_element::Line::new()
-                    .set("x1", top_left.x() + padding.left())
+                    .set("x1", top_left.x())
                     .set("y1", current_y)
-                    .set("x2", top_left.x() + self.size().width() - padding.right())
+                    .set("x2", top_left.x() + expanded_size.width())
                     .set("y2", current_y);
 
                 let separator = crate::apply_stroke!(separator, self.definition.separator_stroke());
@@ -407,14 +446,17 @@ impl Drawable for Fragment {
                 let title_position = if i == 0 {
                     // First section: position to the right of the pentagon
                     Point::new(
-                        pentagon_bounds.max_x() + padding.left() + title_size.width() / 2.0,
+                        pentagon_bounds.max_x() + title_size.width() / 2.0 + padding.left(),
                         pentagon_bounds.center().y(),
                     )
                 } else {
                     // Other sections: position below the separator
                     Point::new(
-                        top_left.x() + padding.left() + title_size.width() / 2.0 + 10.0,
-                        current_y + title_size.height() / 2.0 + 5.0,
+                        top_left.x()
+                            + title_size.width() / 2.0
+                            + bounds_padding.left()
+                            + padding.left(),
+                        current_y + title_size.height() / 2.0,
                     )
                 };
 
@@ -469,6 +511,61 @@ mod tests {
         assert_eq!(definition.separator_stroke().color().to_string(), "black");
         assert_eq!(definition.separator_stroke().width(), 1.0);
         assert_eq!(*definition.separator_stroke().style(), StrokeStyle::Dashed);
+    }
+
+    #[test]
+    fn test_header_size_includes_triangle() {
+        let definition = FragmentDefinition::default();
+        let header = definition.header_size("alt");
+
+        // Header should have positive dimensions.
+        assert!(header.width() > 0.0);
+        assert!(header.height() > 0.0);
+
+        // Header width should be wider than just the text (triangle adds width).
+        let text = Text::new(definition.operation_label_text(), "alt");
+        let text_size = text.calculate_size();
+        assert!(header.width() > text_size.width());
+        assert_eq!(header.height(), text_size.height());
+    }
+
+    #[test]
+    fn test_section_header_size() {
+        let definition = FragmentDefinition::default();
+
+        let with_title = definition.section_header_size(Some("condition"));
+        assert!(with_title.width() > 0.0);
+        assert!(with_title.height() > 0.0);
+
+        let without_title = definition.section_header_size(None);
+        assert_eq!(without_title.width(), 0.0);
+        assert_eq!(without_title.height(), 0.0);
+    }
+
+    #[test]
+    fn test_bottom_padding() {
+        let mut definition = FragmentDefinition::default();
+
+        // Default bounds_padding has bottom = 0.0.
+        assert_eq!(definition.bottom_padding(), 0.0);
+
+        definition.set_bounds_padding(Insets::new(5.0, 10.0, 15.0, 20.0));
+        assert_eq!(definition.bottom_padding(), 15.0);
+    }
+
+    #[test]
+    fn test_triangle_width_clamping() {
+        // Small content
+        let small = FragmentDefinition::triangle_width(Size::new(50.0, 8.0));
+        assert_eq!(small, 4.0); // 8/2 = 4, min(10, 4) = 4, max(8/4=2, 4) = 4
+
+        // Medium content
+        let large = FragmentDefinition::triangle_width(Size::new(50.0, 30.0));
+        assert_eq!(large, 10.0); // 30/2 = 15, min(10, 15) = 10, max(30/4=7.5, 10) = 10
+
+        // Large content
+        let large = FragmentDefinition::triangle_width(Size::new(50.0, 60.0));
+        assert_eq!(large, 15.0); // 60/2 = 30, min(10, 30) = 10, max(60/4=15, 10) = 15
     }
 
     #[test]

--- a/crates/orrery/src/layout/engines/basic/sequence.rs
+++ b/crates/orrery/src/layout/engines/basic/sequence.rs
@@ -248,10 +248,10 @@ impl Engine {
     /// 2. For `SequenceEvent::Relation`: Create [`Message`] centered at `current_y + height/2`, update fragment bounds if inside a fragment, record last relation Y, then advance Y by message size + `event_padding`
     /// 3. For `SequenceEvent::Activate`: Create ActivationTiming at last relation Y position (aligning with the triggering message), push to participant's stack
     /// 4. For `SequenceEvent::Deactivate`: Pop activation, convert to ActivationBox ending at last relation Y position
-    /// 5. For `SequenceEvent::FragmentStart`: Create FragmentTiming and push to fragment stack
-    /// 6. For `SequenceEvent::FragmentSectionStart`: Start new section in current fragment
-    /// 7. For `SequenceEvent::FragmentSectionEnd`: End current section in current fragment
-    /// 8. For `SequenceEvent::FragmentEnd`: Pop fragment, convert to Fragment with final bounds
+    /// 5. For `SequenceEvent::FragmentStart`: Create FragmentTiming at `current_y` and push to fragment stack
+    /// 6. For `SequenceEvent::FragmentSectionStart`: Start new section in current fragment, then advance Y by header height + `event_padding`
+    /// 7. For `SequenceEvent::FragmentSectionEnd`: End current section
+    /// 8. For `SequenceEvent::FragmentEnd`: Pop fragment, convert to Fragment with final bounds, then advance Y by bottom padding + `event_padding`
     /// 9. For `SequenceEvent::Note`: Create positioned [`Note`](draw::Note) at `current_y`, then advance Y by note size + `event_padding`
     ///
     /// # Parameters
@@ -349,12 +349,15 @@ impl Engine {
                 SequenceEvent::FragmentStart(fragment) => {
                     let fragment_timing = FragmentTiming::new(fragment, current_y);
                     fragment_stack.push(fragment_timing);
+                    // No current_y advance here; handled in FragmentSectionStart
                 }
                 SequenceEvent::FragmentSectionStart(fragment_section) => {
                     let fragment_timing = fragment_stack
                         .last_mut()
                         .expect("fragment_timing stack is empty");
                     fragment_timing.start_section(fragment_section, current_y);
+                    current_y += fragment_timing.section_header_height(fragment_section)
+                        + self.event_padding;
                 }
                 SequenceEvent::FragmentSectionEnd => {
                     let fragment_timing = fragment_stack
@@ -366,8 +369,10 @@ impl Engine {
                     let fragment_timing = fragment_stack
                         .pop()
                         .expect("fragment_timing stack is empty");
+                    let fragment_bottom_padding = fragment_timing.bottom_padding();
                     let fragment = fragment_timing.into_fragment(current_y);
                     fragments.push(fragment);
+                    current_y += fragment_bottom_padding + self.event_padding;
                 }
                 SequenceEvent::Note(note) => {
                     let positioned_note =

--- a/crates/orrery/src/layout/sequence.rs
+++ b/crates/orrery/src/layout/sequence.rs
@@ -334,6 +334,32 @@ impl<'a> FragmentTiming<'a> {
         self.max_x = self.max_x.max(source_x.max(target_x));
     }
 
+    /// Returns the height needed for a section's header.
+    ///
+    /// For the first section, returns the max of the fragment header height and the
+    /// section header height, since they render side-by-side. For subsequent sections,
+    /// returns just the section header height.
+    ///
+    /// # Arguments
+    ///
+    /// * `section` - The semantic fragment section to measure.
+    pub fn section_header_height(&self, section: &semantic::FragmentSection) -> f32 {
+        let definition = self.fragment.definition();
+        let section_header_height = definition.section_header_size(section.title()).height();
+
+        if self.sections.is_empty() {
+            let fragment_header_height = definition.header_size(self.fragment.operation()).height();
+            section_header_height.max(fragment_header_height)
+        } else {
+            section_header_height
+        }
+    }
+
+    /// Returns the bottom bounds padding of the fragment.
+    pub fn bottom_padding(&self) -> f32 {
+        self.fragment.definition().bottom_padding()
+    }
+
     /// Converts this timing information into a final positioned Fragment.
     ///
     /// This consumes the `FragmentTiming` and creates a `Fragment` with complete bounds
@@ -827,5 +853,95 @@ mod tests {
         fragment_timing.update_x(40.0, 180.0);
         assert_eq!(fragment_timing.min_x, 30.0);
         assert_eq!(fragment_timing.max_x, 200.0);
+    }
+
+    #[test]
+    fn test_section_header_height_first_section_header_dominates() {
+        // Use a short section title so the fragment header (pentagon) is taller.
+        let fragment_def = Rc::new(draw::FragmentDefinition::default());
+        let section = semantic::FragmentSection::new(Some("x".to_string()), vec![]);
+        let fragment =
+            semantic::Fragment::new("alt".to_string(), vec![section], fragment_def.clone());
+
+        let fragment_timing = FragmentTiming::new(&fragment, 0.0);
+
+        let height = fragment_timing.section_header_height(&fragment.sections()[0]);
+        let header_height = fragment_def.header_size("alt").height();
+
+        assert_eq!(height, header_height);
+    }
+
+    #[test]
+    fn test_section_header_height_first_section_title_dominates() {
+        // Use a multi-line section title so the title is taller than the header.
+        let fragment_def = Rc::new(draw::FragmentDefinition::default());
+        let tall_title = "line1\nline2\nline3\nline4\nline5";
+        let section = semantic::FragmentSection::new(Some(tall_title.to_string()), vec![]);
+        let fragment =
+            semantic::Fragment::new("alt".to_string(), vec![section], fragment_def.clone());
+
+        let fragment_timing = FragmentTiming::new(&fragment, 0.0);
+
+        let height = fragment_timing.section_header_height(&fragment.sections()[0]);
+        let title_height = fragment_def.section_header_size(Some(tall_title)).height();
+
+        assert_eq!(height, title_height);
+    }
+
+    #[test]
+    fn test_section_header_height_subsequent_section() {
+        let fragment_def = Rc::new(draw::FragmentDefinition::default());
+        let section1 = semantic::FragmentSection::new(Some("guard1".to_string()), vec![]);
+        let section2 = semantic::FragmentSection::new(Some("guard2".to_string()), vec![]);
+        let fragment = semantic::Fragment::new(
+            "alt".to_string(),
+            vec![section1, section2],
+            fragment_def.clone(),
+        );
+
+        let mut fragment_timing = FragmentTiming::new(&fragment, 0.0);
+
+        // Complete the first section so sections is no longer empty.
+        fragment_timing.start_section(&fragment.sections()[0], 0.0);
+        fragment_timing.end_section(50.0).unwrap();
+
+        // Second section: should be just the title height.
+        let height = fragment_timing.section_header_height(&fragment.sections()[1]);
+        let title_height = fragment_def.section_header_size(Some("guard2")).height();
+
+        assert_eq!(height, title_height);
+    }
+
+    #[test]
+    fn test_section_header_height_no_title() {
+        let fragment_def = Rc::new(draw::FragmentDefinition::default());
+        let section = semantic::FragmentSection::new(None, vec![]);
+        let fragment =
+            semantic::Fragment::new("opt".to_string(), vec![section], fragment_def.clone());
+
+        let mut fragment_timing = FragmentTiming::new(&fragment, 0.0);
+
+        // Complete first section.
+        fragment_timing.start_section(&fragment.sections()[0], 0.0);
+        fragment_timing.end_section(50.0).unwrap();
+
+        // Subsequent section with no title: height should be 0.
+        let no_title_section = semantic::FragmentSection::new(None, vec![]);
+        let height = fragment_timing.section_header_height(&no_title_section);
+
+        assert_eq!(height, 0.0);
+    }
+
+    #[test]
+    fn test_bottom_padding_delegates_to_definition() {
+        let mut fragment_def = draw::FragmentDefinition::default();
+        fragment_def.set_bounds_padding(orrery_core::geometry::Insets::new(5.0, 10.0, 15.0, 20.0));
+        let fragment_def = Rc::new(fragment_def);
+
+        let fragment = semantic::Fragment::new("loop".to_string(), vec![], fragment_def);
+
+        let fragment_timing = FragmentTiming::new(&fragment, 0.0);
+
+        assert_eq!(fragment_timing.bottom_padding(), 15.0);
     }
 }


### PR DESCRIPTION
## Summary

Add sizing methods to `FragmentDefinition` so the layout engine can correctly reserve vertical space for fragment headers, section title guards, and bottom borders. This prevents elements after a fragment from overlapping with its visual structure.

For the first section, the layout takes the max of the operation label header and section title height since they render side-by-side. Subsequent sections use just the section title height. Fragment end advances by bottom padding.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #36
