### PR TITLE
chore: update cargo homepage to orreryworks.github.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.88"
 authors = ["Foad Nosrati Habibi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/orreryworks/orrery"
-homepage = "https://github.com/orreryworks/orrery"
+homepage = "https://orreryworks.github.io/"
 documentation = "https://docs.rs/orrery"
 
 [workspace.metadata.release]


### PR DESCRIPTION
## Summary

Update the workspace Cargo homepage URL from the GitHub repository to the project website (`https://orreryworks.github.io/`).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Other: metadata update

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [ ] Documentation updated (if applicable)

## Related Issues

N/A
