### PR TITLE
fix: move changelog replacements to single crate to prevent duplicates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,6 @@ shared-version = true
 tag-name = "v{{version}}"
 consolidate-commits = true
 pre-release-commit-message = "release: v{{version}}"
-pre-release-replacements = [
-    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [Unreleased]\n\n## [{{version}}] - {{date}}", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\[Unreleased\\]: (https://github.com/.+/compare/)(.+)\\.\\.\\.HEAD", replace = "[Unreleased]: ${1}v{{version}}...HEAD\n[{{version}}]: ${1}${2}...v{{version}}", exactly = 1 },
-]
 
 [workspace.dependencies]
 orrery = { version = "0.1.0", path = "crates/orrery" }

--- a/crates/orrery-core/Cargo.toml
+++ b/crates/orrery-core/Cargo.toml
@@ -29,3 +29,9 @@ serde = { version = "1.0", features = ["derive"] }
 [dev-dependencies]
 float-cmp = "0.10"
 proptest = "1.10"
+
+[package.metadata.release]
+pre-release-replacements = [
+    { file = "../../CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [Unreleased]\n\n## [{{version}}] - {{date}}", exactly = 1 },
+    { file = "../../CHANGELOG.md", search = "\\[Unreleased\\]: (https://github.com/.+/compare/)(.+)\\.\\.\\.HEAD", replace = "[Unreleased]: ${1}v{{version}}...HEAD\n[{{version}}]: ${1}${2}...v{{version}}", exactly = 1 },
+]


### PR DESCRIPTION
## Summary

Move `pre-release-replacements` from workspace-level `[workspace.metadata.release]` to `orrery-core`'s `[package.metadata.release]`. This prevents `cargo-release` from attempting CHANGELOG.md updates once per crate in the workspace, which failed the `exactly = 1` constraint.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [ ] Documentation updated (if applicable)

## Related Issues

N/A
