### PR TITLE
refactor: add zero() constructors for Point and Size

### DIFF
--- a/crates/orrery-core/src/draw/arrow_with_text.rs
+++ b/crates/orrery-core/src/draw/arrow_with_text.rs
@@ -29,7 +29,7 @@ impl<'a> ArrowWithText<'a> {
     /// The text is positioned at the midpoint of the arrow line.
     fn calculate_text_position(&self, source: Point, destination: Point) -> Point {
         if self.text.is_none() {
-            return Point::default();
+            return Point::zero();
         }
 
         // Position text at the midpoint of the arrow
@@ -164,7 +164,7 @@ mod tests {
         // Without text, should return default point
         let pos =
             arrow_with_text.calculate_text_position(Point::new(0.0, 0.0), Point::new(100.0, 100.0));
-        assert_eq!(pos, Point::default());
+        assert_eq!(pos, Point::zero());
 
         // With text, should return midpoint
         let arrow = create_test_arrow(ArrowDirection::Forward);

--- a/crates/orrery-core/src/draw/fragment.rs
+++ b/crates/orrery-core/src/draw/fragment.rs
@@ -171,7 +171,7 @@ impl FragmentDefinition {
                 let text = Text::new(&self.section_title_text_definition, &formatted);
                 text.calculate_size().add_padding(self.content_padding)
             }
-            None => Size::default(),
+            None => Size::zero(),
         }
     }
 

--- a/crates/orrery-core/src/draw/note.rs
+++ b/crates/orrery-core/src/draw/note.rs
@@ -268,7 +268,7 @@ impl Note {
     /// Calculates the size of the text content without padding.
     fn text_size(&self) -> Size {
         if self.content.is_empty() {
-            return Size::default();
+            return Size::zero();
         }
         let text = Text::new(&self.definition.text, &self.content);
         text.size()

--- a/crates/orrery-core/src/draw/positioned.rs
+++ b/crates/orrery-core/src/draw/positioned.rs
@@ -19,7 +19,7 @@ impl<D: Drawable> PositionedDrawable<D> {
     pub fn new(drawable: D) -> Self {
         Self {
             drawable,
-            position: Point::default(),
+            position: Point::zero(),
         }
     }
 

--- a/crates/orrery-core/src/draw/shape.rs
+++ b/crates/orrery-core/src/draw/shape.rs
@@ -107,7 +107,7 @@ pub trait ShapeDefinition: std::fmt::Debug {
         if self.supports_content() {
             Size::new(10.0, 10.0)
         } else {
-            Size::default() // Content-free shapes don't need content space
+            Size::zero() // Content-free shapes don't need content space
         }
     }
 
@@ -217,7 +217,7 @@ impl Shape {
             shape_size.width() - total_padding_size.width(),
             shape_size.height() - total_padding_size.height(),
         )
-        .max(Size::default())
+        .max(Size::zero())
     }
 
     /// Returns a Point representing the (x, y) offset from the shape's top-left corner

--- a/crates/orrery-core/src/draw/shape_with_text.rs
+++ b/crates/orrery-core/src/draw/shape_with_text.rs
@@ -125,7 +125,7 @@ impl<'a> ShapeWithText<'a> {
     /// Calculates the position where text should be rendered relative to the shape.
     fn calculate_text_position(&self, total_position: Point) -> Point {
         if self.text.is_none() {
-            return Point::default();
+            return Point::zero();
         }
 
         let shape_size = self.shape.inner_size();
@@ -254,7 +254,7 @@ mod tests {
 
         assert_eq!(
             rect_with_text.text_size(),
-            Size::default(),
+            Size::zero(),
             "text_size should be zero when no text (Rectangle)"
         );
         assert_eq!(
@@ -275,7 +275,7 @@ mod tests {
 
         assert_eq!(
             actor_with_text.text_size(),
-            Size::default(),
+            Size::zero(),
             "text_size should be zero when no text (Actor)"
         );
         assert_eq!(
@@ -309,7 +309,7 @@ mod tests {
         let shape_with_text = ShapeWithText::new(shape, None);
         assert_eq!(
             shape_with_text.text_size(),
-            Size::default(),
+            Size::zero(),
             "text_size should return zero when no text"
         );
     }

--- a/crates/orrery-core/src/draw/text.rs
+++ b/crates/orrery-core/src/draw/text.rs
@@ -380,7 +380,7 @@ impl TextManager {
     /// The calculated size in pixels, or default size if measurement fails
     fn calculate_text_size(&self, text: &str, text_def: &TextDefinition) -> Size {
         if text.is_empty() {
-            return Size::default();
+            return Size::zero();
         }
 
         // Lock the FontSystem for use

--- a/crates/orrery-core/src/geometry.rs
+++ b/crates/orrery-core/src/geometry.rs
@@ -52,16 +52,27 @@
 /// assert_eq!(mid.x(), 7.5);
 /// assert_eq!(mid.y(), 12.5);
 /// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Point {
     x: f32,
     y: f32,
+}
+
+impl Default for Point {
+    fn default() -> Self {
+        Self::zero()
+    }
 }
 
 impl Point {
     /// Creates a new point with the specified coordinates
     pub fn new(x: f32, y: f32) -> Self {
         Self { x, y }
+    }
+
+    /// Returns the origin point `(0, 0)`.
+    pub fn zero() -> Self {
+        Self { x: 0.0, y: 0.0 }
     }
 
     /// Returns the x-coordinate.
@@ -173,15 +184,29 @@ impl Point {
 }
 
 /// Width and height of a 2D element.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Size {
     width: f32,
     height: f32,
 }
 
+impl Default for Size {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
 impl Size {
     pub fn new(width: f32, height: f32) -> Self {
         Self { width, height }
+    }
+
+    /// Returns a zero size `(0, 0)`.
+    pub fn zero() -> Self {
+        Self {
+            width: 0.0,
+            height: 0.0,
+        }
     }
 
     /// Returns the width.
@@ -493,11 +518,16 @@ mod tests {
     }
 
     #[test]
-    fn test_point_default() {
-        let point = Point::default();
+    fn test_point_zero() {
+        let point = Point::zero();
         assert_eq!(point.x(), 0.0);
         assert_eq!(point.y(), 0.0);
         assert!(point.is_zero());
+    }
+
+    #[test]
+    fn test_point_default() {
+        assert_eq!(Point::default(), Point::zero());
     }
 
     #[test]
@@ -649,10 +679,15 @@ mod tests {
     }
 
     #[test]
-    fn test_size_default() {
-        let size = Size::default();
+    fn test_size_zero() {
+        let size = Size::zero();
         assert_eq!(size.width(), 0.0);
         assert_eq!(size.height(), 0.0);
+    }
+
+    #[test]
+    fn test_size_default() {
+        assert_eq!(Size::default(), Size::zero());
     }
 
     #[test]
@@ -985,19 +1020,18 @@ mod tests {
 
     #[test]
     fn test_size_is_zero() {
-        // Test zero size
-        let zero_size = Size::new(0.0, 0.0);
+        let new_size = Size::new(0.0, 0.0);
+        assert!(new_size.is_zero());
+
+        let zero_size = Size::zero();
         assert!(zero_size.is_zero());
 
-        // Test default size (should be zero)
         let default_size = Size::default();
         assert!(default_size.is_zero());
 
-        // Test non-zero width
         let non_zero_width = Size::new(1.0, 0.0);
         assert!(!non_zero_width.is_zero());
 
-        // Test non-zero height
         let non_zero_height = Size::new(0.0, 1.0);
         assert!(!non_zero_height.is_zero());
 

--- a/crates/orrery/src/layout/engines/basic/sequence.rs
+++ b/crates/orrery/src/layout/engines/basic/sequence.rs
@@ -123,7 +123,7 @@ impl Engine {
                 let content_size = if let Some(layout) = embedded_layouts.get(&node.id()) {
                     layout.calculate_size()
                 } else {
-                    Size::default()
+                    Size::zero()
                 };
 
                 shape_with_text

--- a/crates/orrery/src/layout/layer.rs
+++ b/crates/orrery/src/layout/layer.rs
@@ -48,7 +48,7 @@ impl<'a> Layer<'a> {
     fn new(z_index: usize, content: LayoutContent<'a>) -> Self {
         Self {
             z_index,
-            offset: Point::default(),
+            offset: Point::zero(),
             clip_bounds: None,
             content,
         }
@@ -285,7 +285,7 @@ where
     pub fn new(content: T) -> Self {
         Self {
             content,
-            offset: Point::default(),
+            offset: Point::zero(),
         }
     }
 


### PR DESCRIPTION
## Summary

Add explicit `zero()` constructors to `Point` and `Size`, replacing derived `Default` with manual impls that delegate to `zero()`. All call sites migrated from `::default()` to `::zero()` for semantic clarity.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Other:

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A
