### PR TITLE
feat(draw): render text backgrounds above all elements except text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Import system specification** — Formal specification for the file-based import system covering `import` syntax, `library;` file header, path resolution, namespaces, diagram embedding via import, scope and visibility, and conflict resolution. Updated main specification and error handling specification with cross-references. ([#44](https://github.com/orreryworks/orrery/issues/44))
 - **Namespaced import system** — Reuse type definitions across files with `import "path";` and `library;` file headers. Imports are namespace-qualified (e.g., `styles::Service`), support transitive chaining, and include circular dependency detection, diamond deduplication, and cross-file error reporting with import traces. ([#45](https://github.com/orreryworks/orrery/issues/45))
+- **Import system specification** — Formal specification for the file-based import system covering `import` syntax, `library;` file header, path resolution, namespaces, diagram embedding via import, scope and visibility, and conflict resolution. Updated main specification and error handling specification with cross-references. ([#44](https://github.com/orreryworks/orrery/issues/44))
+- **Text label background layering** — Text label backgrounds now render above all other diagram elements (arrows, fragments, lifelines, activations, etc.), with only the text itself on top. This ensures labels with a background always remain legible regardless of overlapping elements. ([#75](https://github.com/orreryworks/orrery/issues/75))
 
 ### Changed
 

--- a/crates/orrery-core/src/draw/layer.rs
+++ b/crates/orrery-core/src/draw/layer.rs
@@ -55,6 +55,8 @@ pub enum RenderLayer {
     Note,
     /// Arrows, relations, and messages between elements
     Arrow,
+    /// Backgrounds for text labels
+    TextBackground,
     /// Text labels and annotations
     Text,
 }
@@ -70,6 +72,7 @@ impl RenderLayer {
             Self::Fragment => "fragment",
             Self::Note => "note",
             Self::Arrow => "arrow",
+            Self::TextBackground => "text_background",
             Self::Text => "text",
         }
     }

--- a/crates/orrery-core/src/draw/text.rs
+++ b/crates/orrery-core/src/draw/text.rs
@@ -332,7 +332,7 @@ impl<'a> Drawable for Text<'a> {
                 .set("fill-opacity", bg_color.alpha())
                 .set("rx", 3.0); // Slightly rounded corners
 
-            output.add_to_layer(RenderLayer::Background, Box::new(bg));
+            output.add_to_layer(RenderLayer::TextBackground, Box::new(bg));
         }
 
         output.add_to_layer(RenderLayer::Text, Box::new(rendered_text));


### PR DESCRIPTION
## Summary

Text label backgrounds were rendering on the general Background layer, causing them to appear behind arrows, notes, fragments, and other diagram elements. This defeated their purpose of providing contrast for readability.

This PR adds a dedicated `TextBackground` render layer positioned just below `Text`, so label backgrounds always render above all other diagram elements while remaining beneath the text itself.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #75 