### PR TITLE
feat(parser): add glob import syntax (`import "path"::*;`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Namespaced import system** — Reuse type definitions across files with `import "path";` and `library;` file headers. Imports are namespace-qualified (e.g., `styles::Service`), support transitive chaining, and include circular dependency detection, diamond deduplication, and cross-file error reporting with import traces. ([#45](https://github.com/orreryworks/orrery/issues/45))
+- **Glob import** — Bring all types from a file flat into the current scope with `import "path"::*;`, removing the need for namespace prefixes. Supports last-writer-wins override semantics and transitive re-exports. ([#46](https://github.com/orreryworks/orrery/issues/46))
 - **Import system specification** — Formal specification for the file-based import system covering `import` syntax, `library;` file header, path resolution, namespaces, diagram embedding via import, scope and visibility, and conflict resolution. Updated main specification and error handling specification with cross-references. ([#44](https://github.com/orreryworks/orrery/issues/44))
 - **Text label background layering** — Text label backgrounds now render above all other diagram elements (arrows, fragments, lifelines, activations, etc.), with only the text itself on top. This ensures labels with a background always remain legible regardless of overlapping elements. ([#75](https://github.com/orreryworks/orrery/issues/75))
 

--- a/crates/orrery-parser/src/lexer.rs
+++ b/crates/orrery-parser/src/lexer.rs
@@ -320,7 +320,7 @@ fn single_char_token<'a>(input: &mut Input<'a>) -> IResult<'a, Token<'a>> {
             ']'.value(Token::RightBracket),
             ';'.value(Token::Semicolon),
         )),
-        ','.value(Token::Comma),
+        alt((','.value(Token::Comma), '*'.value(Token::Star))),
     ))
     .parse_next(input)
 }

--- a/crates/orrery-parser/src/parser.rs
+++ b/crates/orrery-parser/src/parser.rs
@@ -1201,7 +1201,7 @@ fn file_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::File
     })
 }
 
-/// Parses a single import declaration: `import "path";`.
+/// Parses a single import declaration: `import "path";` or `import "path"::*;`.
 fn import_decl<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Spanned<types::ImportDecl>> {
     let import_token = any
         .verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Import))
@@ -1211,9 +1211,28 @@ fn import_decl<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Spanned<typ
         let path = string_literal
             .context(Context::Label("import path"))
             .parse_next(input)?;
+
+        // Parse optional `::*` suffix for glob imports.
+        let glob_star = opt(|input: &mut Input<'tok, 'src>| {
+            any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::DoubleColon))
+                .parse_next(input)?;
+            cut_err(input, |input| {
+                any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Star))
+                    .context(Context::Label("'*' after '::'"))
+                    .parse_next(input)
+            })
+        })
+        .parse_next(input)?;
+
+        let (form, end_span) = if let Some(star_token) = glob_star {
+            (types::ImportForm::Glob, star_token.span)
+        } else {
+            (types::ImportForm::Namespaced, path.span())
+        };
+
         semicolon.parse_next(input)?;
-        let span = import_token.span.union(path.span());
-        Ok(make_spanned(types::ImportDecl { path }, span))
+        let span = import_token.span.union(end_span);
+        Ok(make_spanned(types::ImportDecl { path, form }, span))
     })
 }
 
@@ -3659,6 +3678,10 @@ import "shared/styles";"#;
             *file_ast.import_decls[0].inner().path.inner(),
             "shared/styles"
         );
+        assert_eq!(
+            file_ast.import_decls[0].inner().form,
+            types::ImportForm::Namespaced
+        );
     }
 
     #[test]
@@ -3739,18 +3762,85 @@ import "path/to/file";"#;
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         let file_ast = result.unwrap();
         assert_eq!(file_ast.import_decls.len(), 1);
-        let import = &file_ast.import_decls[0];
-        let span = import.span();
         assert_eq!(
-            span.start(),
-            19,
-            "Import span should start at 'import' keyword"
+            file_ast.import_decls[0].inner().form,
+            types::ImportForm::Namespaced
+        );
+        // import(19..25) union "path/to/file"(26..40) = 19..40
+        assert_eq!(file_ast.import_decls[0].span(), Span::from(19..40));
+    }
+
+    #[test]
+    fn test_glob_import() {
+        let input = r#"diagram component;
+import "shared/styles"::*;"#;
+        let tokens = parse_tokens(input);
+        let result = build_file(&tokens);
+        assert!(result.is_ok(), "Failed: {:?}", result.err());
+        let file_ast = result.unwrap();
+        assert_eq!(file_ast.import_decls.len(), 1);
+        let import = file_ast.import_decls[0].inner();
+        assert_eq!(*import.path.inner(), "shared/styles");
+        assert_eq!(import.form, types::ImportForm::Glob);
+        // import(19..25) union *(43..44) = 19..44
+        assert_eq!(file_ast.import_decls[0].span(), Span::from(19..44));
+    }
+
+    #[test]
+    fn test_mixed_namespaced_and_glob_imports() {
+        let input = r#"diagram component;
+import "shared/styles";
+import "common/types"::*;"#;
+        let tokens = parse_tokens(input);
+        let result = build_file(&tokens);
+        assert!(result.is_ok(), "Failed: {:?}", result.err());
+        let file_ast = result.unwrap();
+        assert_eq!(file_ast.import_decls.len(), 2);
+        assert_eq!(
+            file_ast.import_decls[0].inner().form,
+            types::ImportForm::Namespaced
         );
         assert_eq!(
-            span.end(),
-            40,
-            "Import span should end after the path string literal"
+            file_ast.import_decls[1].inner().form,
+            types::ImportForm::Glob
         );
+    }
+
+    #[test]
+    fn test_multiple_glob_imports() {
+        let input = r#"diagram component;
+import "shared/styles"::*;
+import "common/types"::*;"#;
+        let tokens = parse_tokens(input);
+        let result = build_file(&tokens);
+        assert!(result.is_ok(), "Failed: {:?}", result.err());
+        let file_ast = result.unwrap();
+        assert_eq!(file_ast.import_decls.len(), 2);
+        assert_eq!(
+            file_ast.import_decls[0].inner().form,
+            types::ImportForm::Glob
+        );
+        assert_eq!(
+            file_ast.import_decls[1].inner().form,
+            types::ImportForm::Glob
+        );
+    }
+
+    #[test]
+    fn test_glob_import_in_library() {
+        let input = r#"library;
+import "base/types"::*;
+type Service = Rectangle;"#;
+        let tokens = parse_tokens(input);
+        let result = build_file(&tokens);
+        assert!(result.is_ok(), "Failed: {:?}", result.err());
+        let file_ast = result.unwrap();
+        assert_eq!(file_ast.import_decls.len(), 1);
+        assert_eq!(
+            file_ast.import_decls[0].inner().form,
+            types::ImportForm::Glob
+        );
+        assert_eq!(file_ast.type_definitions.len(), 1);
     }
 
     #[test]

--- a/crates/orrery-parser/src/parser_tests.rs
+++ b/crates/orrery-parser/src/parser_tests.rs
@@ -3,7 +3,13 @@
 //! These tests verify that the winnow parser correctly handles all Orrery
 //! language constructs and provides proper error handling.
 
-use crate::{lexer, parser};
+use std::path::Path;
+
+use bumpalo::Bump;
+
+use orrery_core::{identifier::Id, semantic::Element};
+
+use crate::{ElaborateConfig, InMemorySourceProvider, lexer, parse, parser};
 
 /// Helper function to parse a source string and return success/failure
 fn parse_source(source: &str) -> Result<(), String> {
@@ -1473,5 +1479,314 @@ mod typespec_case_tests {
             app: Rectangle[color="blue";
         "#;
         assert_parse_fails(source);
+    }
+}
+
+mod import_tests {
+    use super::*;
+
+    #[test]
+    fn test_namespaced_import_library_types() {
+        let mut provider = InMemorySourceProvider::new();
+        provider.add_file(
+            "shared/styles.orr",
+            r#"
+            library;
+            type Service = Rectangle[fill_color="lightblue"];
+            type Database = Oval[fill_color="lightgreen"];
+        "#,
+        );
+        provider.add_file(
+            "main.orr",
+            r#"
+            diagram component;
+            import "shared/styles";
+
+            api: styles::Service;
+            db: styles::Database;
+        "#,
+        );
+
+        let arena = Bump::new();
+        let diagram = parse(
+            &arena,
+            Path::new("main.orr"),
+            provider,
+            ElaborateConfig::default(),
+        )
+        .expect("Failed to parse");
+
+        let elements = diagram.scope().elements();
+        assert_eq!(elements.len(), 2);
+        assert!(matches!(&elements[0], Element::Node(n) if n.id() == Id::new("api")));
+        assert!(matches!(&elements[1], Element::Node(n) if n.id() == Id::new("db")));
+    }
+
+    #[test]
+    fn test_namespaced_import_transitive_library() {
+        let mut provider = InMemorySourceProvider::new();
+        provider.add_file(
+            "base.orr",
+            r#"
+            library;
+            type Service = Rectangle[fill_color="lightblue"];
+        "#,
+        );
+        provider.add_file(
+            "extended.orr",
+            r#"
+            library;
+            import "base";
+
+            type SecureService = base::Service[stroke=[color="red"]];
+        "#,
+        );
+        provider.add_file(
+            "main.orr",
+            r#"
+            diagram component;
+            import "extended";
+
+            api: extended::SecureService;
+            svc: extended::base::Service;
+        "#,
+        );
+
+        let arena = Bump::new();
+        let diagram = parse(
+            &arena,
+            Path::new("main.orr"),
+            provider,
+            ElaborateConfig::default(),
+        )
+        .expect("Failed to parse");
+
+        let elements = diagram.scope().elements();
+        assert_eq!(elements.len(), 2);
+        assert!(matches!(&elements[0], Element::Node(n) if n.id() == Id::new("api")));
+        assert!(matches!(&elements[1], Element::Node(n) if n.id() == Id::new("svc")));
+    }
+
+    #[test]
+    fn test_namespaced_import_diamond_dependency() {
+        let mut provider = InMemorySourceProvider::new();
+        provider.add_file(
+            "base.orr",
+            r#"
+            library;
+            type Service = Rectangle[fill_color="lightblue"];
+        "#,
+        );
+        provider.add_file(
+            "ext_a.orr",
+            r#"
+            library;
+            import "base";
+
+            type ServiceA = base::Service[stroke=[color="red"]];
+        "#,
+        );
+        provider.add_file(
+            "ext_b.orr",
+            r#"
+            library;
+            import "base";
+
+            type ServiceB = base::Service[stroke=[color="blue"]];
+        "#,
+        );
+        provider.add_file(
+            "main.orr",
+            r#"
+            diagram component;
+            import "ext_a";
+            import "ext_b";
+
+            a: ext_a::ServiceA;
+            b: ext_b::ServiceB;
+        "#,
+        );
+
+        let arena = Bump::new();
+        let diagram = parse(
+            &arena,
+            Path::new("main.orr"),
+            provider,
+            ElaborateConfig::default(),
+        )
+        .expect("Failed to parse");
+
+        let elements = diagram.scope().elements();
+        assert_eq!(elements.len(), 2);
+        assert!(matches!(&elements[0], Element::Node(n) if n.id() == Id::new("a")));
+        assert!(matches!(&elements[1], Element::Node(n) if n.id() == Id::new("b")));
+    }
+
+    #[test]
+    fn test_glob_import_library_types() {
+        let mut provider = InMemorySourceProvider::new();
+        provider.add_file(
+            "shared/styles.orr",
+            r#"
+            library;
+            type Service = Rectangle[fill_color="lightblue"];
+            type Database = Oval[fill_color="lightgreen"];
+        "#,
+        );
+        provider.add_file(
+            "main.orr",
+            r#"
+            diagram component;
+            import "shared/styles"::*;
+
+            api: Service;
+            db: Database;
+        "#,
+        );
+
+        let arena = Bump::new();
+        let diagram = parse(
+            &arena,
+            Path::new("main.orr"),
+            provider,
+            ElaborateConfig::default(),
+        )
+        .expect("Failed to parse");
+
+        let elements = diagram.scope().elements();
+        assert_eq!(elements.len(), 2);
+        assert!(matches!(&elements[0], Element::Node(n) if n.id() == Id::new("api")));
+        assert!(matches!(&elements[1], Element::Node(n) if n.id() == Id::new("db")));
+    }
+
+    #[test]
+    fn test_glob_import_override_last_writer_wins() {
+        let mut provider = InMemorySourceProvider::new();
+        provider.add_file(
+            "theme_a.orr",
+            r#"
+            library;
+            type Service = Rectangle[fill_color="blue"];
+        "#,
+        );
+        provider.add_file(
+            "theme_b.orr",
+            r#"
+            library;
+            type Service = Rectangle[fill_color="red"];
+        "#,
+        );
+        provider.add_file(
+            "main.orr",
+            r#"
+            diagram component;
+            import "theme_a"::*;
+            import "theme_b"::*;
+
+            api: Service;
+        "#,
+        );
+
+        let arena = Bump::new();
+        let diagram = parse(
+            &arena,
+            Path::new("main.orr"),
+            provider,
+            ElaborateConfig::default(),
+        )
+        .expect("Failed to parse");
+
+        let elements = diagram.scope().elements();
+        assert_eq!(elements.len(), 1);
+        assert!(matches!(&elements[0], Element::Node(n) if n.id() == Id::new("api")));
+    }
+
+    #[test]
+    fn test_mixed_namespaced_and_glob_imports() {
+        let mut provider = InMemorySourceProvider::new();
+        provider.add_file(
+            "styles.orr",
+            r#"
+            library;
+            type Service = Rectangle[fill_color="lightblue"];
+        "#,
+        );
+        provider.add_file(
+            "types.orr",
+            r#"
+            library;
+            type Database = Oval[fill_color="lightgreen"];
+        "#,
+        );
+        provider.add_file(
+            "main.orr",
+            r#"
+            diagram component;
+            import "styles";
+            import "types"::*;
+
+            api: styles::Service;
+            db: Database;
+        "#,
+        );
+
+        let arena = Bump::new();
+        let diagram = parse(
+            &arena,
+            Path::new("main.orr"),
+            provider,
+            ElaborateConfig::default(),
+        )
+        .expect("Failed to parse");
+
+        let elements = diagram.scope().elements();
+        assert_eq!(elements.len(), 2);
+        assert!(matches!(&elements[0], Element::Node(n) if n.id() == Id::new("api")));
+        assert!(matches!(&elements[1], Element::Node(n) if n.id() == Id::new("db")));
+    }
+
+    #[test]
+    fn test_glob_import_transitive_library() {
+        let mut provider = InMemorySourceProvider::new();
+        provider.add_file(
+            "base.orr",
+            r#"
+            library;
+            type Service = Rectangle[fill_color="lightblue"];
+        "#,
+        );
+        provider.add_file(
+            "extended.orr",
+            r#"
+            library;
+            import "base"::*;
+
+            type SecureService = Service[stroke=[color="red"]];
+        "#,
+        );
+        provider.add_file(
+            "main.orr",
+            r#"
+            diagram component;
+            import "extended"::*;
+
+            api: SecureService;
+            svc: Service;
+        "#,
+        );
+
+        let arena = Bump::new();
+        let diagram = parse(
+            &arena,
+            Path::new("main.orr"),
+            provider,
+            ElaborateConfig::default(),
+        )
+        .expect("Failed to parse");
+
+        let elements = diagram.scope().elements();
+        assert_eq!(elements.len(), 2);
+        assert!(matches!(&elements[0], Element::Node(n) if n.id() == Id::new("api")));
+        assert!(matches!(&elements[1], Element::Node(n) if n.id() == Id::new("svc")));
     }
 }

--- a/crates/orrery-parser/src/parser_types.rs
+++ b/crates/orrery-parser/src/parser_types.rs
@@ -297,7 +297,22 @@ impl FileHeader<'_> {
     }
 }
 
-/// Import declaration — a syntactic `import "path";` statement.
+/// The syntactic form of an import declaration.
+///
+/// Determines how imported types are brought into scope — behind a namespace
+/// prefix or flat into the current scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportForm {
+    /// `import "path";` — all types behind a derived namespace, accessed as
+    /// `namespace::TypeName`.
+    Namespaced,
+    /// `import "path"::*;` — all types flat in the current scope, no namespace
+    /// prefix required.
+    Glob,
+}
+
+/// Import declaration — a syntactic `import "path";` or `import "path"::*;`
+/// statement.
 ///
 /// Captures the raw import path exactly as written in source. The path is a
 /// string literal without the `.orr` extension, resolved relative to the
@@ -307,6 +322,8 @@ pub struct ImportDecl {
     /// The import path string (e.g., `"shared/styles"`), wrapped in
     /// [`Spanned`].
     pub path: Spanned<String>,
+    /// The syntactic [`ImportForm`] — namespaced or glob.
+    pub form: ImportForm,
 }
 
 /// Resolved import — populated by the resolver after parsing.

--- a/crates/orrery-parser/src/resolver.rs
+++ b/crates/orrery-parser/src/resolver.rs
@@ -38,10 +38,10 @@ use crate::{
     error::{Diagnostic, ErrorCode, ParseError, SourceError},
     file_id::FileId,
     lexer, parser,
-    parser_types::{FileAst, Import},
+    parser_types::{FileAst, Import, ImportDecl, ImportForm},
     source_map::SourceMap,
     source_provider::SourceProvider,
-    span::Span,
+    span::{Span, Spanned},
 };
 
 /// The output of resolving a root Orrery file and all of its transitive
@@ -207,27 +207,8 @@ impl<'arena, P: SourceProvider> Resolver<'arena, P> {
 
         // 9. Resolve each import declaration and populate `file_ast.imports`.
         for import_decl in &file_ast.import_decls {
-            let import_path = &import_decl.path;
-            let decl_span = import_decl.span();
-
-            Self::validate_import_path(import_path, decl_span).map_err(|diag| vec![diag])?;
-
-            let resolved_path = self
-                .provider
-                .resolve_path(path, import_path)
-                .map_err(|e| vec![Self::file_not_found_diagnostic(&e, Some(decl_span))])?;
-
-            let imported_rc = self.resolve_file(&resolved_path, Some(decl_span))?;
-
-            let namespace = self
-                .provider
-                .derive_namespace(&resolved_path)
-                .map_err(|e| vec![Self::invalid_namespace_diagnostic(&e, decl_span)])?;
-
-            file_ast.imports.push(Import {
-                namespace: Some(namespace),
-                file_ast: imported_rc,
-            });
+            let import = self.resolve_import_decl(path, import_decl)?;
+            file_ast.imports.push(import);
         }
 
         // 10. Pop from the resolution stack and cache the result.
@@ -236,6 +217,54 @@ impl<'arena, P: SourceProvider> Resolver<'arena, P> {
         self.cache.insert(file_id, Rc::clone(&rc));
 
         Ok(rc)
+    }
+
+    /// Resolves a single [`ImportDecl`] into a fully populated [`Import`].
+    ///
+    /// Validates the path, recursively resolves the referenced file, and
+    /// derives the namespace (for namespaced imports) or leaves it `None`
+    /// (for glob imports).
+    ///
+    /// # Errors
+    ///
+    /// Returns diagnostics if:
+    /// - The referenced file cannot be found (E400).
+    /// - A circular dependency is detected (E401).
+    /// - The import path is empty (E402).
+    /// - The namespace cannot be derived from the file path (E403,
+    ///   namespaced imports only).
+    fn resolve_import_decl(
+        &mut self,
+        parent_path: &Path,
+        import_decl: &Spanned<ImportDecl>,
+    ) -> Result<Import<'arena>, Vec<Diagnostic>> {
+        let import_path = &import_decl.path;
+        let decl_span = import_decl.span();
+
+        Self::validate_import_path(import_path, decl_span).map_err(|diag| vec![diag])?;
+
+        let resolved_path = self
+            .provider
+            .resolve_path(parent_path, import_path)
+            .map_err(|e| vec![Self::file_not_found_diagnostic(&e, Some(decl_span))])?;
+
+        let file_ast = self.resolve_file(&resolved_path, Some(decl_span))?;
+
+        let namespace = match import_decl.inner().form {
+            ImportForm::Namespaced => {
+                let ns = self
+                    .provider
+                    .derive_namespace(&resolved_path)
+                    .map_err(|e| vec![Self::invalid_namespace_diagnostic(&e, decl_span)])?;
+                Some(ns)
+            }
+            ImportForm::Glob => None,
+        };
+
+        Ok(Import {
+            namespace,
+            file_ast,
+        })
     }
 
     /// Rejects empty import paths, which would silently mis-resolve to the

--- a/crates/orrery-parser/src/tokens.rs
+++ b/crates/orrery-parser/src/tokens.rs
@@ -50,6 +50,7 @@ pub enum Token<'src> {
     Equals,      // =
     Colon,       // :
     DoubleColon, // ::
+    Star,        // *
     At,          // @
 
     // Punctuation
@@ -152,6 +153,7 @@ impl fmt::Display for Token<'_> {
             Token::Equals => write!(f, "="),
             Token::Colon => write!(f, ":"),
             Token::DoubleColon => write!(f, "::"),
+            Token::Star => write!(f, "*"),
             Token::At => write!(f, "@"),
 
             Token::LeftBrace => write!(f, "{{"),


### PR DESCRIPTION
## Summary

Add the glob import form (`import "path"::*;`) that brings all types from a file flat into the current scope without a namespace prefix.

Changes:
- **Lexer**: Add `Token::Star` for `*`.
- **AST**: Add `ImportForm` enum (`Namespaced` | `Glob`) and `form` field to `ImportDecl`.
- **Parser**: Extend `import_decl` to parse optional `::*` suffix after the path string.
- **Resolver**: Extract `resolve_import_decl` method; glob imports set `namespace: None`, skipping namespace derivation.
- **No changes** to desugar, validate, or elaborate — the desugar phase already handled the `namespace: None` case.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #46 
