### PR TITLE
feat(layout): implement graphviz layout engine for component diagrams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,22 +17,22 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - uses: actions/checkout@v6
       - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-hack
+      - uses: actions/checkout@v6
       - run: cargo hack clippy --workspace --all-targets --feature-powerset -- -D warnings
 
   docs:
@@ -41,10 +41,10 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-hack
+      - uses: actions/checkout@v6
       - run: cargo hack doc --workspace --no-deps --feature-powerset
 
   test:
@@ -55,7 +55,7 @@ jobs:
       matrix:
         toolchain: [stable, "1.88"]
     steps:
-      - uses: actions/checkout@v6
+      - run: sudo apt-get update && sudo apt-get install -y graphviz
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -63,4 +63,5 @@ jobs:
         with:
           key: ${{ matrix.toolchain }}
       - uses: taiki-e/install-action@cargo-hack
+      - uses: actions/checkout@v6
       - run: cargo hack test --workspace --feature-powerset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,7 +165,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -172,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
 
@@ -207,7 +216,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -263,11 +272,40 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -290,6 +328,21 @@ dependencies = [
  "redox_users",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "dot-generator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aaac7ada45f71873ebce336491d1c1bc4a7c8042c7cea978168ad59e805b871"
+dependencies = [
+ "dot-structures",
+]
+
+[[package]]
+name = "dot-structures"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cfcded997a93eb31edd639361fa33fd229a8784e953b37d71035fe3890b7b"
 
 [[package]]
 name = "env_filter"
@@ -416,6 +469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +520,22 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "graphviz-rust"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3f0630e2e2d6bef34313acf63330e2ce87144f5dfef276abeeef9345dd5bf3"
+dependencies = [
+ "dot-generator",
+ "dot-structures",
+ "into-attr",
+ "into-attr-derive",
+ "pest",
+ "pest_derive",
+ "rand 0.9.2",
+ "tempfile",
+]
 
 [[package]]
 name = "harfrust"
@@ -511,6 +590,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "into-attr"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b48c537e49a709e678caec3753a7dba6854661a1eaa27675024283b3f8b376"
+dependencies = [
+ "dot-structures",
+]
+
+[[package]]
+name = "into-attr-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecac7c1ae6cd2c6a3a64d1061a8bdc7f52ff62c26a831a2301e54c1b5d70d5b1"
+dependencies = [
+ "dot-generator",
+ "dot-structures",
+ "into-attr",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,7 +650,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -649,7 +750,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -704,6 +805,9 @@ dependencies = [
  "bumpalo",
  "color",
  "cosmic-text",
+ "dot-generator",
+ "dot-structures",
+ "graphviz-rust",
  "indexmap",
  "layout-rs",
  "log",
@@ -771,6 +875,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,7 +960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1091,7 +1238,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1123,6 +1270,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -1300,6 +1458,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -1368,7 +1537,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1439,6 +1608,18 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -1743,7 +1924,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1759,7 +1940,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1830,7 +2011,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cargo build --release
 
 ### Optional Features
 
-- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default.
+- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default. Requires the `dot` command-line tool to be installed (see <https://graphviz.org/download/>).
 
 ```bash
 # Build the workspace with the Graphviz layout engine enabled

--- a/crates/orrery-cli/README.md
+++ b/crates/orrery-cli/README.md
@@ -18,7 +18,7 @@ cargo install orrery-cli
 
 ### Optional Features
 
-- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default.
+- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default. Requires the `dot` command-line tool to be installed (see <https://graphviz.org/download/>).
 
 ```bash
 # Install with the Graphviz layout engine enabled

--- a/crates/orrery/Cargo.toml
+++ b/crates/orrery/Cargo.toml
@@ -18,7 +18,7 @@ name = "orrery"
 path = "src/lib.rs"
 
 [features]
-graphviz = ["orrery-core/graphviz"]
+graphviz = ["orrery-core/graphviz", "dep:graphviz-rust", "dep:dot-structures", "dep:dot-generator"]
 
 [dependencies]
 orrery-core = { workspace = true }
@@ -36,5 +36,8 @@ rand = "0.10.1"
 rust-sugiyama = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.27.0"
+graphviz-rust = { version = "0.9.7", optional = true }
+dot-structures = { version = "0.1.2", optional = true }
+dot-generator = { version = "0.2.0", optional = true }
 
 [dev-dependencies]

--- a/crates/orrery/README.md
+++ b/crates/orrery/README.md
@@ -13,7 +13,7 @@ orrery = "0.1.0"
 
 ### Optional Features
 
-- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default.
+- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default. Requires the `dot` command-line tool to be installed (see <https://graphviz.org/download/>).
 
 ```toml
 [dependencies]

--- a/crates/orrery/src/layout/engines.rs
+++ b/crates/orrery/src/layout/engines.rs
@@ -212,7 +212,8 @@ impl EngineBuilder {
                     }
                     #[cfg(feature = "graphviz")]
                     LayoutEngine::Graphviz => {
-                        let e = graphviz::Component::new();
+                        let mut e = graphviz::Component::new();
+                        e.set_container_padding(self.padding);
                         Box::new(e)
                     }
                 };

--- a/crates/orrery/src/layout/engines/graphviz/component.rs
+++ b/crates/orrery/src/layout/engines/graphviz/component.rs
@@ -1,25 +1,60 @@
 //! Graphviz layout engine for component diagrams.
 //!
-//! Provides a [`ComponentEngine`] implementation that delegates spatial
-//! positioning to Graphviz. Component positions and relation routes come
-//! from Graphviz.
+//! Translates [`ComponentGraph`] containment scopes into DOT graphs,
+//! invokes Graphviz `dot` for positioning, and maps the results back
+//! into Orrery's [`Layout`] representation.
+//!
+//! # Data Flow
+//!
+//! ```text
+//! ComponentGraph
+//!     ↓ build_graphviz_graph
+//! dot_structures::Graph
+//!     ↓ run_graphviz (dot -Tdot -y)
+//! dot_structures::Graph (with pos attributes)
+//!     ↓ extract_positions_from_graph
+//! HashMap<Id, Point>
+//!     ↓ calculate_layout
+//! ContentStack<Layout>
+//! ```
+
+use std::{collections::HashMap, rc::Rc};
+
+use dot_structures::{
+    Attribute, Edge, EdgeTy, Graph as DotGraph, Id as DotId, Node as DotNode, NodeId, Stmt, Vertex,
+};
+use graphviz_rust::{
+    cmd::{CommandArg, Format},
+    printer::PrinterContext,
+};
+use log::{debug, trace};
+
+use orrery_core::{
+    draw::{self, ArrowDirection, Drawable},
+    geometry::{Insets, Point, Size},
+    identifier::Id,
+    semantic,
+};
 
 use crate::{
     error::RenderError,
     layout::{
-        component::Layout,
+        component::{Component, Layout, LayoutRelation, adjust_positioned_contents_offset},
         engines::{ComponentEngine, EmbeddedLayouts},
-        layer::ContentStack,
+        layer::{ContentStack, PositionedContent},
     },
-    structure::ComponentGraph,
+    structure::{ComponentGraph, ContainmentScope},
 };
+
+/// Points per inch — Graphviz uses inches for node dimensions.
+const POINTS_PER_INCH: f32 = 72.0;
 
 /// Graphviz-based layout engine for component diagrams.
 ///
-/// Computes component positions and relation routes by invoking Graphviz
-/// on a translation of the [`ComponentGraph`]. The resulting coordinates
-/// are converted back into Orrery's [`Layout`] representation, preserving
-/// the diagram's components, relations, and styling.
+/// Computes component positions by invoking the Graphviz `dot` command
+/// on a translation of each [`ContainmentScope`] in the
+/// [`ComponentGraph`]. Relation directionality influences hierarchical
+/// ranking via Graphviz's `constraint` attribute.
 ///
 /// # Examples
 ///
@@ -28,51 +63,420 @@ use crate::{
 /// let engine = GraphvizComponent::new();
 /// let layout = engine.calculate(&graph, &embedded_layouts)?;
 /// ```
-pub struct Engine {}
+pub struct Engine {
+    /// Padding inside container components.
+    container_padding: Insets,
+}
 
 impl Engine {
-    /// Creates a new Graphviz component layout engine with default settings.
+    /// Creates a new engine with default container padding.
     pub fn new() -> Self {
-        Self {}
+        Self {
+            container_padding: Insets::uniform(20.0),
+        }
+    }
+
+    /// Sets the padding inside container components.
+    pub fn set_container_padding(&mut self, padding: Insets) -> &mut Self {
+        self.container_padding = padding;
+        self
     }
 
     /// Calculates a component layout by delegating to Graphviz.
     ///
-    /// Translates the component graph into a Graphviz description, invokes
-    /// Graphviz to obtain positions for every node and control points for
-    /// every relation, and converts the result back into a
-    /// [`ContentStack`] of [`Layout`] values — one entry per containment
-    /// scope, in post-order.
-    ///
-    /// Embedded diagrams are not re-laid out here: their sizes are taken
-    /// from `embedded_layouts` so that container components reserve exactly
-    /// the space their inner diagrams need.
+    /// Iterates containment scopes in post-order: inner scopes are laid out
+    /// first so their sizes are available when sizing their parent containers.
     ///
     /// # Arguments
     ///
     /// * `graph` - The component diagram graph to lay out.
-    /// * `embedded_layouts` - Pre-calculated layouts for any embedded
-    ///   diagrams, indexed by node [`Id`](orrery_core::identifier::Id).
-    ///   Looked up instead of recomputed whenever a node hosts an embedded
-    ///   diagram.
+    /// * `embedded_layouts` - Pre-calculated layouts for embedded diagrams,
+    ///   indexed by node [`Id`].
     ///
     /// # Returns
     ///
-    /// A [`ContentStack`] of component layouts, one per containment scope,
-    /// with positions and relation routes filled in.
+    /// A [`ContentStack`] of component layouts with positions filled in.
     ///
     /// # Errors
     ///
-    /// Returns [`RenderError::Layout`] if the Graphviz invocation fails or
-    /// its output cannot be parsed back into a valid layout, or if an
-    /// embedded diagram's layout is missing from `embedded_layouts`.
+    /// Returns [`RenderError::Layout`] if Graphviz invocation fails, output
+    /// cannot be parsed, or an embedded layout is missing.
     fn calculate_layout<'a>(
         &self,
-        _graph: &'a ComponentGraph<'a, '_>,
-        _embedded_layouts: &EmbeddedLayouts<'a>,
+        graph: &'a ComponentGraph<'a, '_>,
+        embedded_layouts: &EmbeddedLayouts<'a>,
     ) -> Result<ContentStack<Layout<'a>>, RenderError> {
-        todo!()
+        let mut content_stack = ContentStack::<Layout<'a>>::new();
+        let mut positioned_content_sizes = HashMap::<Id, Size>::new();
+
+        for containment_scope in graph.containment_scopes() {
+            // Calculate component shapes - they contain all sizing information
+            let mut component_shapes = self.calculate_component_shapes(
+                graph,
+                containment_scope,
+                &positioned_content_sizes,
+                embedded_layouts,
+            )?;
+
+            // Extract sizes from shapes for Graphviz node sizing
+            let component_sizes: HashMap<Id, Size> = component_shapes
+                .iter()
+                .map(|(idx, shape_with_text)| (*idx, shape_with_text.size()))
+                .collect();
+
+            // Calculate positions using Graphviz
+            let positions = self.positions(graph, containment_scope, &component_sizes)?;
+
+            // Build the final component list using the pre-configured shapes
+            let mut components: Vec<Component> = Vec::new();
+            for node in graph.scope_nodes(containment_scope) {
+                let position = *positions.get(&node.id()).ok_or_else(|| {
+                    RenderError::Layout(format!("position not found for node `{node}`"))
+                })?;
+                let shape_with_text = component_shapes.remove(&node.id()).ok_or_else(|| {
+                    RenderError::Layout(format!("shape not found for node `{node}`"))
+                })?;
+
+                // If this node contains an embedded diagram, adjust position to normalize
+                // the embedded layout's coordinate system to start at origin
+                let final_position = if let semantic::Block::Diagram(_) = node.block()
+                    && let Some(layout) = embedded_layouts.get(&node.id())
+                {
+                    position.add_point(layout.normalize_offset())
+                } else {
+                    position
+                };
+
+                components.push(Component::new(node, shape_with_text, final_position));
+            }
+
+            // Map node IDs to their component indices
+            let component_indices: HashMap<_, _> = components
+                .iter()
+                .enumerate()
+                .map(|(idx, component)| (component.node_id(), idx))
+                .collect();
+
+            // Build the list of relations between components
+            let relations: Vec<LayoutRelation> = graph
+                .scope_relations(containment_scope)
+                .filter_map(|relation| {
+                    // Only include relations between visible components
+                    // (not including relations within inner blocks)
+                    if let (Some(&source_index), Some(&target_index)) = (
+                        component_indices.get(&relation.source()),
+                        component_indices.get(&relation.target()),
+                    ) {
+                        Some(LayoutRelation::from_ast(
+                            relation,
+                            source_index,
+                            target_index,
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let positioned_content = PositionedContent::new(Layout::new(components, relations));
+
+            if let Some(container) = containment_scope.container() {
+                // If this layer is a container, we need to adjust its size based on its contents
+                let size = positioned_content.layout_size();
+                positioned_content_sizes.insert(container, size);
+            }
+            content_stack.push(positioned_content);
+        }
+
+        adjust_positioned_contents_offset(&mut content_stack, graph)?;
+
+        Ok(content_stack)
     }
+
+    /// Calculates sized shapes for all components in a containment scope.
+    ///
+    /// Embedded diagram and inner scope sizes are resolved from previously
+    /// computed layouts so that container nodes reserve the correct area.
+    fn calculate_component_shapes<'a>(
+        &self,
+        graph: &'a ComponentGraph<'a, '_>,
+        containment_scope: &ContainmentScope,
+        positioned_content_sizes: &HashMap<Id, Size>,
+        embedded_layouts: &EmbeddedLayouts<'a>,
+    ) -> Result<HashMap<Id, draw::ShapeWithText<'a>>, RenderError> {
+        let mut component_shapes: HashMap<Id, draw::ShapeWithText<'a>> = HashMap::new();
+
+        for node in graph.scope_nodes(containment_scope) {
+            let mut shape = draw::Shape::new(Rc::clone(node.shape_definition()));
+            shape.set_padding(self.container_padding);
+            let text = draw::Text::new(node.shape_definition().text(), node.display_text());
+            let mut shape_with_text = draw::ShapeWithText::new(shape, Some(text));
+
+            match node.block() {
+                semantic::Block::Diagram(_) => {
+                    // Since we process in post-order (innermost to outermost),
+                    // embedded diagram layouts should already be calculated and available
+                    let layout = embedded_layouts.get(&node.id()).ok_or_else(|| {
+                        RenderError::Layout(format!("embedded layout not found for node `{node}`"))
+                    })?;
+
+                    let content_size = layout.calculate_size();
+                    shape_with_text
+                        .set_inner_content_size(content_size)
+                        .map_err(|err| {
+                            RenderError::Layout(format!(
+                                "cannot set content size for diagram block `{node}`: {err}"
+                            ))
+                        })?;
+                }
+                semantic::Block::Scope(_) => {
+                    let content_size =
+                        *positioned_content_sizes.get(&node.id()).ok_or_else(|| {
+                            RenderError::Layout(format!("scope size not found for node `{node}`"))
+                        })?;
+                    shape_with_text
+                        .set_inner_content_size(content_size)
+                        .map_err(|err| {
+                            RenderError::Layout(format!(
+                                "cannot set content size for scope block `{node}`: {err}"
+                            ))
+                        })?;
+                }
+                semantic::Block::None => {
+                    // No content to size, so don't call set_inner_content_size
+                }
+            };
+            component_shapes.insert(node.id(), shape_with_text);
+        }
+
+        Ok(component_shapes)
+    }
+
+    /// Computes node positions via Graphviz `dot -Tdot -y`.
+    ///
+    /// Positions are in points (72 per inch). The `-y` flag makes
+    /// Graphviz output Y increasing downward, matching Orrery's
+    /// coordinate system.
+    fn positions(
+        &self,
+        graph: &ComponentGraph<'_, '_>,
+        containment_scope: &ContainmentScope,
+        component_sizes: &HashMap<Id, Size>,
+    ) -> Result<HashMap<Id, Point>, RenderError> {
+        if containment_scope.nodes_count() == 0 {
+            return Ok(HashMap::new());
+        }
+
+        // Build the Graphviz graph structure
+        let gv_graph = self.build_graphviz_graph(graph, containment_scope, component_sizes)?;
+
+        // Execute Graphviz layout
+        let laid_out_graph = run_graphviz(gv_graph)?;
+
+        // Extract node positions from the annotated output
+        let positions = extract_positions_from_graph(&laid_out_graph)?;
+
+        if positions.len() != containment_scope.nodes_count() {
+            return Err(RenderError::Layout(format!(
+                "graphviz produced {} positions, expected {}",
+                positions.len(),
+                containment_scope.nodes_count(),
+            )));
+        }
+
+        Ok(positions)
+    }
+
+    /// Translates a containment scope into a [`DotGraph`].
+    ///
+    /// Nodes are sized in inches (`fixedsize=true`) and edges carry
+    /// `dir`/`constraint` attributes based on [`ArrowDirection`].
+    fn build_graphviz_graph(
+        &self,
+        graph: &ComponentGraph<'_, '_>,
+        containment_scope: &ContainmentScope,
+        component_sizes: &HashMap<Id, Size>,
+    ) -> Result<DotGraph, RenderError> {
+        let mut stmts: Vec<Stmt> = Vec::new();
+
+        // Graph-level attributes
+        stmts.push(Stmt::Attribute(dot_attr("rankdir", "TB")));
+        stmts.push(Stmt::Attribute(dot_attr("nodesep", "0.5")));
+        stmts.push(Stmt::Attribute(dot_attr("ranksep", "0.75")));
+
+        // Add nodes with size attributes
+        for node in graph.scope_nodes(containment_scope) {
+            // Convert size from points/pixels to inches for Graphviz
+            let size = component_sizes.get(&node.id()).ok_or_else(|| {
+                RenderError::Layout(format!("component size not found for node `{node}`"))
+            })?;
+            let width_inches = size.width() / POINTS_PER_INCH;
+            let height_inches = size.height() / POINTS_PER_INCH;
+
+            let width_str = format!("{width_inches:.4}");
+            let height_str = format!("{height_inches:.4}");
+            let gv_node = DotNode::new(
+                NodeId(DotId::Plain(node.id().to_string()), None),
+                vec![
+                    dot_attr("shape", "box"),
+                    dot_attr("fixedsize", "true"),
+                    Attribute(DotId::Plain("width".into()), DotId::Plain(width_str)),
+                    Attribute(DotId::Plain("height".into()), DotId::Plain(height_str)),
+                ],
+            );
+            stmts.push(Stmt::Node(gv_node));
+        }
+
+        // Add edges for relations within this scope
+        for relation in graph.scope_relations(containment_scope) {
+            let attributes = match relation.arrow_direction() {
+                ArrowDirection::Forward => vec![],
+                ArrowDirection::Backward => vec![dot_attr("dir", "back")],
+                ArrowDirection::Bidirectional => {
+                    vec![dot_attr("dir", "both"), dot_attr("constraint", "false")]
+                }
+                ArrowDirection::Plain => {
+                    vec![dot_attr("dir", "none"), dot_attr("constraint", "false")]
+                }
+            };
+            let edge = Edge {
+                ty: EdgeTy::Pair(
+                    Vertex::N(NodeId(DotId::Plain(relation.source().to_string()), None)),
+                    Vertex::N(NodeId(DotId::Plain(relation.target().to_string()), None)),
+                ),
+                attributes,
+            };
+            stmts.push(Stmt::Edge(edge));
+        }
+
+        Ok(DotGraph::DiGraph {
+            id: DotId::Plain("scope".into()),
+            strict: true,
+            stmts,
+        })
+    }
+}
+
+/// Creates a DOT [`Attribute`] from a key-value string pair.
+fn dot_attr(key: &str, value: &str) -> Attribute {
+    Attribute(DotId::Plain(key.into()), DotId::Plain(value.into()))
+}
+
+/// Executes Graphviz `dot` and returns the annotated graph.
+///
+/// Passes `-Tdot` to get DOT output with layout attributes injected,
+/// and `-y` to invert the Y-axis to match screen coordinates.
+///
+/// # Errors
+///
+/// Returns [`RenderError::Layout`] if:
+/// - The `dot` command cannot be spawned.
+/// - The process exits with a non-zero status.
+/// - The output cannot be re-parsed into a DOT graph.
+fn run_graphviz(gv_graph: DotGraph) -> Result<DotGraph, RenderError> {
+    // Execute Graphviz with DOT output and -y to invert the Y-axis
+    let output = graphviz_rust::exec(
+        gv_graph,
+        &mut PrinterContext::default(),
+        vec![
+            CommandArg::Format(Format::Dot),
+            CommandArg::Custom("-y".into()),
+        ],
+    )
+    .map_err(|err| {
+        RenderError::Layout(format!(
+            "cannot execute `dot` command, is Graphviz installed? {err}"
+        ))
+    })?;
+
+    let dot_output = String::from_utf8(output)
+        .map_err(|err| RenderError::Layout(format!("graphviz output is not valid UTF-8: {err}")))?;
+
+    debug!(dot_output:%; "Graphviz DOT output");
+
+    // Re-parse the DOT output into a structured graph
+    graphviz_rust::parse(&dot_output)
+        .map_err(|err| RenderError::Layout(format!("cannot parse graphviz DOT output: {err}")))
+}
+
+/// Extracts node positions from a Graphviz-annotated DOT graph.
+///
+/// Reads the `pos` attribute (`"x,y"` in points) from each node statement.
+/// Positions are used directly — the `-y` flag already aligns output with
+/// Orrery's Y-down coordinate system.
+///
+/// # Errors
+///
+/// Returns [`RenderError::Layout`] if any node lacks a `pos` attribute
+/// or the value cannot be parsed.
+fn extract_positions_from_graph(graph: &DotGraph) -> Result<HashMap<Id, Point>, RenderError> {
+    let stmts = match graph {
+        DotGraph::Graph { stmts, .. } | DotGraph::DiGraph { stmts, .. } => stmts,
+    };
+
+    let mut positions = HashMap::new();
+
+    for node in stmts.iter().filter_map(|stmt| match stmt {
+        Stmt::Node(node) => Some(node),
+        _ => None,
+    }) {
+        let node_name = dot_id_to_str(&node.id.0);
+
+        let pos_str = find_attribute(&node.attributes, "pos").ok_or_else(|| {
+            RenderError::Layout(format!(
+                "node `{node_name}` missing `pos` attribute after graphviz layout"
+            ))
+        })?;
+
+        let pos = parse_pos_str(pos_str).ok_or_else(|| {
+            RenderError::Layout(format!(
+                "cannot parse `pos` value `{pos_str}` for node `{node_name}`"
+            ))
+        })?;
+
+        positions.insert(Id::new(node_name), pos);
+
+        trace!(
+            node_name,
+            pos:?;
+            "Extracted Graphviz position",
+        );
+    }
+
+    Ok(positions)
+}
+
+/// Extracts the raw string from a [`DotId`].
+///
+/// The `Escaped` variant includes surrounding double quotes which are
+/// stripped to yield the inner content.
+fn dot_id_to_str(id: &DotId) -> &str {
+    match id {
+        DotId::Escaped(s) => s.trim_matches('"'),
+        DotId::Plain(s) | DotId::Html(s) | DotId::Anonymous(s) => s,
+    }
+}
+
+/// Finds an attribute value by key in a list of DOT attributes.
+fn find_attribute<'a>(attributes: &'a [Attribute], key: &str) -> Option<&'a str> {
+    attributes.iter().find_map(|Attribute(k, v)| {
+        if dot_id_to_str(k) == key {
+            Some(dot_id_to_str(v))
+        } else {
+            None
+        }
+    })
+}
+
+/// Parses a Graphviz `pos` value (`"x,y"`) into a [`Point`].
+///
+/// Strips an optional trailing `!` (pinned position indicator).
+fn parse_pos_str(pos_str: &str) -> Option<Point> {
+    let cleaned = pos_str.trim().trim_end_matches('!');
+    let (x_str, y_str) = cleaned.split_once(',')?;
+    let x: f32 = x_str.trim().parse().ok()?;
+    let y: f32 = y_str.trim().parse().ok()?;
+    Some(Point::new(x, y))
 }
 
 impl ComponentEngine for Engine {
@@ -90,8 +494,127 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_engine_basics() {
-        // Create a minimal engine and ensure it can be instantiated
-        let _engine = Engine::new();
+    fn test_parse_pos_value_basic() {
+        assert_eq!(parse_pos_str("72,108"), Some(Point::new(72.0, 108.0)));
+    }
+
+    #[test]
+    fn test_parse_pos_value_with_pin() {
+        assert_eq!(parse_pos_str("50.5,75.3!"), Some(Point::new(50.5, 75.3)));
+    }
+
+    #[test]
+    fn test_parse_pos_value_invalid() {
+        assert_eq!(parse_pos_str(""), None);
+        assert_eq!(parse_pos_str("abc,def"), None);
+        assert_eq!(parse_pos_str("100"), None);
+    }
+
+    #[test]
+    fn test_extract_positions_from_graph() {
+        // Build a graph that simulates Graphviz DOT output with pos attributes
+        let graph = DotGraph::DiGraph {
+            id: DotId::Plain("scope".into()),
+            strict: true,
+            stmts: vec![
+                Stmt::Node(DotNode::new(
+                    NodeId(DotId::Plain("component_a".into()), None),
+                    vec![
+                        dot_attr("pos", "72,144"),
+                        dot_attr("width", "1.0"),
+                        dot_attr("height", "0.75"),
+                    ],
+                )),
+                Stmt::Node(DotNode::new(
+                    NodeId(DotId::Plain("component_b".into()), None),
+                    vec![
+                        dot_attr("pos", "72,36"),
+                        dot_attr("width", "1.0"),
+                        dot_attr("height", "0.75"),
+                    ],
+                )),
+            ],
+        };
+
+        let positions = extract_positions_from_graph(&graph).expect("positions extraction failed");
+
+        let id_a = Id::new("component_a");
+        let id_b = Id::new("component_b");
+
+        assert_eq!(positions.len(), 2);
+        assert!(positions.contains_key(&id_a));
+        assert!(positions.contains_key(&id_b));
+
+        let pos_a = positions[&id_a];
+        assert!((pos_a.x() - 72.0).abs() < 0.01);
+        assert!((pos_a.y() - 144.0).abs() < 0.01);
+
+        let pos_b = positions[&id_b];
+        assert!((pos_b.x() - 72.0).abs() < 0.01);
+        assert!((pos_b.y() - 36.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_extract_positions_empty_graph() {
+        let graph = DotGraph::DiGraph {
+            id: DotId::Plain("empty".into()),
+            strict: true,
+            stmts: vec![],
+        };
+        let positions = extract_positions_from_graph(&graph).expect("positions extraction failed");
+        assert!(positions.is_empty());
+    }
+
+    #[test]
+    fn test_run_graphviz_and_extract_positions() {
+        // This test requires graphviz to be installed
+        let gv_graph = DotGraph::DiGraph {
+            id: DotId::Plain("test".into()),
+            strict: true,
+            stmts: vec![
+                Stmt::Attribute(dot_attr("rankdir", "TB")),
+                Stmt::Node(DotNode::new(
+                    NodeId(DotId::Plain("n0".into()), None),
+                    vec![
+                        dot_attr("shape", "box"),
+                        dot_attr("fixedsize", "true"),
+                        dot_attr("width", "1.0"),
+                        dot_attr("height", "0.75"),
+                    ],
+                )),
+                Stmt::Node(DotNode::new(
+                    NodeId(DotId::Plain("n1".into()), None),
+                    vec![
+                        dot_attr("shape", "box"),
+                        dot_attr("fixedsize", "true"),
+                        dot_attr("width", "1.0"),
+                        dot_attr("height", "0.75"),
+                    ],
+                )),
+                Stmt::Edge(Edge {
+                    ty: EdgeTy::Pair(
+                        Vertex::N(NodeId(DotId::Plain("n0".into()), None)),
+                        Vertex::N(NodeId(DotId::Plain("n1".into()), None)),
+                    ),
+                    attributes: vec![],
+                }),
+            ],
+        };
+
+        let laid_out_graph = run_graphviz(gv_graph).expect("graphviz execution failed");
+        let positions =
+            extract_positions_from_graph(&laid_out_graph).expect("positions extraction failed");
+
+        let id0 = Id::new("n0");
+        let id1 = Id::new("n1");
+
+        assert_eq!(positions.len(), 2);
+        assert!(positions.contains_key(&id0));
+        assert!(positions.contains_key(&id1));
+
+        // With rankdir=TB and -y flag: n0 (source) is at top (smaller Y)
+        let pos0 = positions[&id0];
+        let pos1 = positions[&id1];
+        assert!(pos0.y() < pos1.y(), "n0 should be above n1 (smaller Y)");
     }
 }


### PR DESCRIPTION
## Summary

Implements the Graphviz layout engine for component diagrams, making `layout_engine="graphviz"` functional.

- Add graphviz-rust, dot-structures, dot-generator as optional deps
- Set edge dir/constraint attributes based on ArrowDirection
- Configure container_padding from EngineBuilder
- Document graphviz CLI requirement in READMEs

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #93
