### PR TITLE
feat: make Graphviz the default layout engine for the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Graphviz layout engine for component diagrams** — Component diagrams can now select Graphviz as their layout engine with `layout_engine="graphviz"`, delegating spatial positioning to Graphviz for more balanced placements and fewer relation crossings on non-trivial graphs. Gated behind the optional `graphviz` Cargo feature, disabled by default. ([#88](https://github.com/orreryworks/orrery/issues/88))
+- **Graphviz layout engine for component diagrams** — Component diagrams can now select Graphviz as their layout engine with `layout_engine="graphviz"`, delegating spatial positioning to Graphviz for more balanced placements and fewer relation crossings on non-trivial graphs. Gated behind the optional `graphviz` Cargo feature (disabled by default for library crates, enabled by default in the CLI). ([#88](https://github.com/orreryworks/orrery/issues/88))
 
 ## [0.2.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cargo build --release
 
 ### Optional Features
 
-- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default. Requires the `dot` command-line tool to be installed (see <https://graphviz.org/download/>).
+- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default for library crates, enabled by default in the CLI. Requires the `dot` command-line tool to be installed (see <https://graphviz.org/download/>).
 
 ```bash
 # Build the workspace with the Graphviz layout engine enabled

--- a/crates/orrery-cli/Cargo.toml
+++ b/crates/orrery-cli/Cargo.toml
@@ -22,6 +22,7 @@ name = "orrery"
 path = "src/main.rs"
 
 [features]
+default = ["graphviz"]
 graphviz = ["orrery/graphviz", "orrery-parser/graphviz"]
 
 [dependencies]

--- a/crates/orrery-cli/README.md
+++ b/crates/orrery-cli/README.md
@@ -18,14 +18,14 @@ cargo install orrery-cli
 
 ### Optional Features
 
-- `graphviz` — Enables the Graphviz-backed layout engine for component diagrams. Disabled by default. Requires the `dot` command-line tool to be installed (see <https://graphviz.org/download/>).
+- `graphviz` *(enabled by default)* — Enables the Graphviz-backed layout engine for component diagrams. Requires the `dot` command-line tool to be installed (see <https://graphviz.org/download/>).
 
 ```bash
-# Install with the Graphviz layout engine enabled
-cargo install --path . --features graphviz
+# Install without the Graphviz layout engine
+cargo install --path . --no-default-features
 
 # Or from crates.io
-cargo install orrery-cli --features graphviz
+cargo install orrery-cli --no-default-features
 ```
 
 ## Usage

--- a/crates/orrery-core/src/semantic/diagram.rs
+++ b/crates/orrery-core/src/semantic/diagram.rs
@@ -63,22 +63,25 @@ impl Scope {
 ///
 /// # Variants
 ///
-/// - [`Basic`](Self::Basic) - Simple layout algorithm (default).
+/// - [`Basic`](Self::Basic) - Simple layout algorithm (default without `graphviz` feature).
 /// - [`Sugiyama`](Self::Sugiyama) - Hierarchical layered layout using the Sugiyama method.
 /// - `Graphviz` - Graphviz-backed layout engine. Only present when the
-///   `graphviz` Cargo feature is enabled.
+///   `graphviz` Cargo feature is enabled. When enabled, this becomes the default layout engine.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LayoutEngine {
-    /// Basic layout engine (default).
-    #[default]
-    Basic,
-    /// Sugiyama hierarchical layout engine.
-    Sugiyama,
-    /// Graphviz-backed layout engine for component diagrams.
+    /// Simple built-in layout algorithm.
     ///
-    /// Gated by the `graphviz` Cargo feature.
+    /// Default when the `graphviz` feature is disabled.
+    #[cfg_attr(not(feature = "graphviz"), default)]
+    Basic,
+    /// Hierarchical layered layout using the Sugiyama method.
+    Sugiyama,
+    /// Graphviz-backed layout engine.
+    ///
+    /// Gated by the `graphviz` Cargo feature. When enabled, this becomes the default layout engine.
     #[cfg(feature = "graphviz")]
+    #[cfg_attr(feature = "graphviz", default)]
     Graphviz,
 }
 
@@ -232,6 +235,9 @@ mod tests {
 
     #[test]
     fn test_layout_engine_default() {
+        #[cfg(feature = "graphviz")]
+        assert_eq!(LayoutEngine::default(), LayoutEngine::Graphviz);
+        #[cfg(not(feature = "graphviz"))]
         assert_eq!(LayoutEngine::default(), LayoutEngine::Basic);
     }
 


### PR DESCRIPTION
## Summary

Makes Graphviz the default layout engine for component diagrams when installed via the CLI. The `graphviz` Cargo feature is now enabled by default in `orrery-cli`, and `LayoutEngine::default()` conditionally returns `Graphviz` when the feature is active. Library crates remain opt-in. Users can still override with `layout_engine="basic"` or install with `--no-default-features`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #97
