### PR TITLE
docs(spec): document graphviz layout engine

### DIFF
--- a/docs/specifications/specification.md
+++ b/docs/specifications/specification.md
@@ -1004,6 +1004,7 @@ Available layout engines:
 
 - `basic`: The default layout engine with simple positioning (available for both component and sequence diagrams)
 - `sugiyama`: A hierarchical layout engine for layered diagrams (available for component diagrams)
+- `graphviz`: Graphviz-backed hierarchical layout via the external `dot` CLI (component diagrams only; requires the `graphviz` Cargo feature)
 
 ### 10.1 Component Diagrams
 
@@ -1257,7 +1258,8 @@ The configuration file uses TOML syntax and supports the following settings:
 ```toml
 # Layout engine configuration
 [layout]
-# Default layout engine for component diagrams (basic, sugiyama)
+# Default layout engine for component diagrams (basic, sugiyama, graphviz*)
+# *graphviz requires the `graphviz` Cargo feature to be enabled
 component = "basic"
 # Default layout engine for sequence diagrams (basic)
 sequence = "basic"
@@ -1284,10 +1286,11 @@ Color values must be valid CSS color strings.
 
 The layout engine names in the configuration file are string representations of the internal enum values:
 
-| String Value | Layout Engine Type | Supported Diagram Types       |
-|--------------|-------------------|------------------------------|
-| "basic"      | Basic layout      | Component, Sequence          |
-| "sugiyama"   | Hierarchical      | Component                    |
+| String Value | Layout Engine Type | Supported Diagram Types       | Build Requirement            |
+|--------------|-------------------|------------------------------|------------------------------|
+| "basic"      | Basic layout      | Component, Sequence          | Always available             |
+| "sugiyama"   | Hierarchical      | Component                    | Always available             |
+| "graphviz"   | Graphviz (dot)    | Component                    | `graphviz` Cargo feature     |
 
 ### 14.4 Style Configuration
 
@@ -1319,7 +1322,7 @@ When determining which styles or layout engines to use, Orrery follows this prio
 
 1. Explicit layout engine in diagram declaration (`layout_engine` attribute)
 2. Default layout engine in configuration file (if found in any of the search locations)
-3. Built-in default (`basic`)
+3. Built-in default (`graphviz` when the `graphviz` Cargo feature is enabled, otherwise `basic`)
 
 #### Style Priority
 


### PR DESCRIPTION
## Summary

Document the `graphviz` layout engine in the language specification. Updates §10 (available engines list), §14.2 (config file comments), §14.3 (engine values table), and §14.6 (default priority) to include `graphviz` alongside `basic` and `sugiyama`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #90
