### PR TITLE
docs(examples): add Graphviz to layout engines comparison

### DIFF
--- a/crates/orrery-cli/tests/e2e_smoke_test.rs
+++ b/crates/orrery-cli/tests/e2e_smoke_test.rs
@@ -41,7 +41,13 @@ fn e2e_smoke_test_valid_examples() {
         .parent()
         .unwrap()
         .join("examples");
-    let valid_examples = collect_orr_files(examples_path);
+    let mut valid_examples = collect_orr_files(examples_path.clone());
+
+    // Include feature-gated examples when the corresponding feature is enabled
+    #[cfg(feature = "graphviz")]
+    valid_examples.extend(collect_orr_files(examples_path.join("feat_graphviz")));
+
+    valid_examples.sort();
 
     assert!(
         !valid_examples.is_empty(),

--- a/docs/architecture/examples.md
+++ b/docs/architecture/examples.md
@@ -4,7 +4,7 @@ This document defines the conventions for the `examples/` directory. Examples se
 
 ## Directory Structure
 
-All examples live in a flat directory. Error examples live in `errors/`.
+All examples live in a flat directory. Error examples live in `errors/`. Feature-gated examples live in `feat_<feature>/` directories.
 
 ```
 examples/
@@ -12,6 +12,8 @@ examples/
 ├── component_*.orr
 ├── sequence_*.orr
 ├── <cross-cutting>.orr
+├── feat_<feature>/
+│   └── <feature-gated examples>.orr
 └── errors/
     ├── README.md
     ├── lexer_*.orr
@@ -19,6 +21,14 @@ examples/
     ├── elab_*.orr
     └── validate_*.orr
 ```
+
+### Feature-Gated Directories
+
+Examples that require an optional Cargo feature live in a `feat_<feature>/` subdirectory. The `feat_` prefix signals that the directory is tied to a compile-time feature flag. Files inside follow the same naming conventions as top-level examples.
+
+The E2E smoke test includes these directories only when the corresponding feature is enabled via `#[cfg(feature = "...")]`.
+
+A feature-gated example may duplicate a top-level example with additional feature-specific content.
 
 ## Naming Conventions
 

--- a/docs/specifications/specification.md
+++ b/docs/specifications/specification.md
@@ -1004,6 +1004,7 @@ Available layout engines:
 
 - `basic`: The default layout engine with simple positioning (available for both component and sequence diagrams)
 - `sugiyama`: A hierarchical layout engine for layered diagrams (available for component diagrams)
+- `graphviz`: Graphviz-backed hierarchical layout via the external `dot` CLI (component diagrams only; requires the `graphviz` Cargo feature)
 
 ### 10.1 Component Diagrams
 
@@ -1257,7 +1258,8 @@ The configuration file uses TOML syntax and supports the following settings:
 ```toml
 # Layout engine configuration
 [layout]
-# Default layout engine for component diagrams (basic, sugiyama)
+# Default layout engine for component diagrams (basic, sugiyama, graphviz*)
+# *graphviz requires the `graphviz` Cargo feature to be enabled
 component = "basic"
 # Default layout engine for sequence diagrams (basic)
 sequence = "basic"
@@ -1284,10 +1286,11 @@ Color values must be valid CSS color strings.
 
 The layout engine names in the configuration file are string representations of the internal enum values:
 
-| String Value | Layout Engine Type | Supported Diagram Types       |
-|--------------|-------------------|------------------------------|
-| "basic"      | Basic layout      | Component, Sequence          |
-| "sugiyama"   | Hierarchical      | Component                    |
+| String Value | Layout Engine Type | Supported Diagram Types       | Build Requirement            |
+|--------------|-------------------|------------------------------|------------------------------|
+| "basic"      | Basic layout      | Component, Sequence          | Always available             |
+| "sugiyama"   | Hierarchical      | Component                    | Always available             |
+| "graphviz"   | Graphviz (dot)    | Component                    | `graphviz` Cargo feature     |
 
 ### 14.4 Style Configuration
 
@@ -1319,7 +1322,7 @@ When determining which styles or layout engines to use, Orrery follows this prio
 
 1. Explicit layout engine in diagram declaration (`layout_engine` attribute)
 2. Default layout engine in configuration file (if found in any of the search locations)
-3. Built-in default (`basic`)
+3. Built-in default (`graphviz` when the `graphviz` Cargo feature is enabled, otherwise `basic`)
 
 #### Style Priority
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ The generated SVG is saved as `out.svg` in the current directory.
 | [`component_basic.orr`](component_basic.orr) | Component definitions, display names (`as "..."`), relation types (`->`, `<-`, `<->`, `-`), labels |
 | [`component_shapes.orr`](component_shapes.orr) | All built-in shapes: Rectangle, Oval, Component, Actor, Entity, Control, Interface, Boundary; content-free vs content-supporting |
 | [`component_nesting.orr`](component_nesting.orr) | Nested components, multi-level nesting, cross-level relations (`parent::child`) |
-| [`component_layout_engines.orr`](component_layout_engines.orr) | Basic vs Sugiyama layout engines side-by-side |
+| [`component_layout_engines.orr`](component_layout_engines.orr) | Basic, Sugiyama, and Graphviz layout engines side-by-side |
 
 ### Sequence Diagrams
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ The generated SVG is saved as `out.svg` in the current directory.
 | [`component_basic.orr`](component_basic.orr) | Component definitions, display names (`as "..."`), relation types (`->`, `<-`, `<->`, `-`), labels |
 | [`component_shapes.orr`](component_shapes.orr) | All built-in shapes: Rectangle, Oval, Component, Actor, Entity, Control, Interface, Boundary; content-free vs content-supporting |
 | [`component_nesting.orr`](component_nesting.orr) | Nested components, multi-level nesting, cross-level relations (`parent::child`) |
-| [`component_layout_engines.orr`](component_layout_engines.orr) | Basic, Sugiyama, and Graphviz layout engines side-by-side |
+| [`component_layout_engines.orr`](component_layout_engines.orr) | Basic vs Sugiyama layout engines side-by-side |
 
 ### Sequence Diagrams
 
@@ -38,6 +38,16 @@ The generated SVG is saved as `out.svg` in the current directory.
 | [`imports.orr`](imports.orr) | Namespaced import, glob import (`::*`), `as` alias, transitive chaining (`sec::styles::Type`), diagram embedding via import |
 
 > The [`imports/`](imports/) directory contains supporting library and diagram files used by `imports.orr` and `embedded_diagrams.orr`.
+
+### Feature-Gated Examples
+
+Examples in `feat_<feature>/` directories require the corresponding Cargo feature to be enabled.
+
+#### `feat_graphviz/` — requires `graphviz` feature
+
+| File | Features |
+|------|----------|
+| [`component_layout_engines.orr`](feat_graphviz/component_layout_engines.orr) | Basic, Sugiyama, and Graphviz layout engines side-by-side |
 
 ### Error Examples
 

--- a/examples/component_layout_engines.orr
+++ b/examples/component_layout_engines.orr
@@ -1,8 +1,9 @@
 // Layout Engines
 //
 // Demonstrates:
-//   - Basic layout engine (default)
+//   - Basic layout engine
 //   - Sugiyama layout engine (layered graph layout for DAGs)
+//   - Graphviz layout engine (requires `graphviz` feature and `dot` CLI)
 //   - Layout engine attribute on diagram declarations
 //   - Same graph rendered with different engines for comparison
 
@@ -52,4 +53,27 @@ sugiyama_system as "Sugiyama Engine": Rectangle embed {
     orders -> cache;
 };
 
+// --- Embedded: Graphviz Engine ---
+
+graphviz_system as "Graphviz Engine": Rectangle embed {
+    diagram component [layout_engine="graphviz", background_color="#ffffff"];
+    type Service = Rectangle [fill_color="#e6f3ff", rounded=5];
+    type Database = Rectangle [fill_color="#e0f0e0", rounded=10];
+    gateway as "API Gateway": Service;
+    auth as "Auth Service": Service;
+    users as "User Service": Service;
+    orders as "Order Service": Service;
+    db as "Primary DB": Database;
+    cache as "Cache": Database;
+
+    gateway -> auth;
+    gateway -> users;
+    gateway -> orders;
+    auth -> db;
+    users -> db;
+    orders -> db;
+    orders -> cache;
+};
+
 basic_system -> sugiyama_system: "Compare";
+sugiyama_system -> graphviz_system: "Compare";

--- a/examples/feat_graphviz/component_layout_engines.orr
+++ b/examples/feat_graphviz/component_layout_engines.orr
@@ -1,8 +1,9 @@
-// Layout Engines
+// Layout Engines (with Graphviz)
 //
 // Demonstrates:
-//   - Basic layout engine (default)
+//   - Basic layout engine
 //   - Sugiyama layout engine (layered graph layout for DAGs)
+//   - Graphviz layout engine (requires `graphviz` feature and `dot` CLI)
 //   - Layout engine attribute on diagram declarations
 //   - Same graph rendered with different engines for comparison
 
@@ -52,4 +53,27 @@ sugiyama_system as "Sugiyama Engine": Rectangle embed {
     orders -> cache;
 };
 
+// --- Embedded: Graphviz Engine ---
+
+graphviz_system as "Graphviz Engine": Rectangle embed {
+    diagram component [layout_engine="graphviz", background_color="#ffffff"];
+    type Service = Rectangle [fill_color="#e6f3ff", rounded=5];
+    type Database = Rectangle [fill_color="#e0f0e0", rounded=10];
+    gateway as "API Gateway": Service;
+    auth as "Auth Service": Service;
+    users as "User Service": Service;
+    orders as "Order Service": Service;
+    db as "Primary DB": Database;
+    cache as "Cache": Database;
+
+    gateway -> auth;
+    gateway -> users;
+    gateway -> orders;
+    auth -> db;
+    users -> db;
+    orders -> db;
+    orders -> cache;
+};
+
 basic_system -> sugiyama_system: "Compare";
+sugiyama_system -> graphviz_system: "Compare";


### PR DESCRIPTION
## Summary

Add a third embedded diagram using `layout_engine="graphviz"` to `component_layout_engines.orr` so all three layout engines (Basic, Sugiyama, Graphviz) are shown side-by-side. Update `examples/README.md` to reflect the addition.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #91
