### PR TITLE
feat: add default semi-transparent background for arrow text labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Graphviz layout engine for component diagrams** — Component diagrams can now select Graphviz as their layout engine with `layout_engine="graphviz"`, delegating spatial positioning to Graphviz for more balanced placements and fewer relation crossings on non-trivial graphs. Gated behind the optional `graphviz` Cargo feature (disabled by default for library crates, enabled by default in the CLI). ([#88](https://github.com/orreryworks/orrery/issues/88))
+- **Default arrow text background** — Relation labels now render with a semi-transparent white background (`rgba(255, 255, 255, 0.85)`) by default, making text readable when overlapping the arrow line. ([#101](https://github.com/orreryworks/orrery/issues/101))
 
 ## [0.2.0] - 2026-04-20
 

--- a/crates/orrery-core/src/draw/arrow.rs
+++ b/crates/orrery-core/src/draw/arrow.rs
@@ -96,10 +96,14 @@ impl ArrowDefinition {
 
 impl Default for ArrowDefinition {
     fn default() -> Self {
+        let mut text_def = TextDefinition::default();
+        text_def.set_background_color(Some(
+            Color::new("rgba(255, 255, 255, 0.85)").expect("valid color"),
+        ));
         Self {
             stroke: Rc::new(StrokeDefinition::default()),
             style: ArrowStyle::default(),
-            text: Rc::new(TextDefinition::default()),
+            text: Rc::new(text_def),
         }
     }
 }


### PR DESCRIPTION
## Summary

Relation labels now render with a default semi-transparent white background (`rgba(255, 255, 255, 0.85)`), making text readable when it overlaps the arrow line. Users can still override this via `text=[background_color="..."]` on individual relations or arrow types.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #101
