### PR TITLE
refactor(examples): use non-default background color in styling example

### DIFF
--- a/examples/styling.orr
+++ b/examples/styling.orr
@@ -63,7 +63,7 @@ server -> @PatternArrow client: "Custom dash pattern (5,3,2,3)";
 
 client -> [stroke=[color="darkorange", width=2.5], text=[color="darkorange", font_size=14, font_family="Arial"]] server: "Inline stroke + text";
 
-server -> [stroke=[color="rgb(100, 149, 237)", width=2.0, style="dashed"], text=[color="#4169e1", background_color="white", padding=3.0]] store: "RGB stroke, highlighted label";
+server -> [stroke=[color="rgb(100, 149, 237)", width=2.0, style="dashed"], text=[color="#4169e1", background_color="peachpuff", padding=3.0]] store: "RGB stroke, highlighted label";
 
 // --- Color Format Showcase on Relations ---
 


### PR DESCRIPTION
## Summary

Replace "white" with "peachpuff" for `background_color` in the styling example, since white is now the default arrow text background color and no longer demonstrates the feature effectively.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A
