### PR TITLE
feat(core)!: accept external control points in arrow rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Edge routing for parallel edges, reverse edges, and self-loops** — Multiple arrows between the same components now render as separate, visually distinguishable curves. Reverse arrows render on opposite sides, and self-referencing relations render as visible loops. ([#104](https://github.com/orreryworks/orrery/issues/104))
+
+### Changed
+
+- **BREAKING: Default `ArrowStyle` changed to `Curved`** — The default arrow style is now `Curved` (was `Straight`). `Curved` renders a straight line when no control points are provided, and follows bezier control points when they are. ([#106](https://github.com/orreryworks/orrery/issues/106))
+- **BREAKING: Arrow rendering API accepts control points** — `ArrowDrawer::draw_arrow`, `ArrowWithText::render_to_layers`, and `ArrowWithTextDrawer::draw_arrow_with_text` now require an additional `control_points: &[Point]` parameter. Pass `&[]` to preserve previous behavior. ([#106](https://github.com/orreryworks/orrery/issues/106))
+
 ## [0.3.0] - 2026-05-03
 
 ### Added

--- a/crates/orrery-core/src/draw/arrow.rs
+++ b/crates/orrery-core/src/draw/arrow.rs
@@ -22,8 +22,8 @@ use crate::{
 /// - `Orthogonal`: Creates only horizontal and vertical line segments
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ArrowStyle {
-    #[default]
     Straight,
+    #[default]
     Curved,
     Orthogonal,
 }
@@ -176,18 +176,33 @@ pub struct ArrowDrawer {
 }
 
 impl ArrowDrawer {
-    /// Draws an arrow and collects its color for marker generation
+    /// Draws an arrow between two points and collects its color for marker generation.
+    ///
+    /// Only arrows with [`ArrowStyle::Curved`] use the provided `control_points`.
+    /// Other styles ([`ArrowStyle::Straight`], [`ArrowStyle::Orthogonal`]) ignore them entirely.
+    ///
+    /// # Arguments
+    ///
+    /// * `arrow` - The arrow to render.
+    /// * `source` - Starting point of the arrow.
+    /// * `destination` - Ending point of the arrow.
+    /// * `control_points` - Bezier control points for [`ArrowStyle::Curved`] arrows.
+    ///   - `[]` — falls back to a straight line.
+    ///   - `[cp]` — quadratic bezier curve.
+    ///   - `[cp1, cp2]` — cubic bezier curve.
+    ///   - 3+ points — chained cubic bezier segments with midpoint anchors.
     pub fn draw_arrow(
         &mut self,
         arrow: &Arrow,
         source: Point,
         destination: Point,
+        control_points: &[Point],
     ) -> Box<dyn svg::Node> {
         self.register_arrow_markers(arrow);
-        arrow.render_to_svg(source, destination)
+        arrow.render_to_svg(source, destination, control_points)
     }
 
-    /// Generates SVG marker definitions for all collected colors
+    /// Generates SVG marker definitions for all collected arrow colors.
     pub fn draw_marker_definitions(&self) -> Box<dyn svg::Node> {
         let mut defs = svg_element::Definitions::new();
         for color in self.heads.values() {
@@ -225,6 +240,11 @@ impl Arrow {
         }
     }
 
+    /// Returns the arrow's [`ArrowStyle`].
+    pub fn style(&self) -> ArrowStyle {
+        self.definition.style
+    }
+
     /// Returns the minimum [`Size`] needed to render this arrow.
     pub fn min_size(&self) -> Size {
         let (marker_width, marker_height) = match self.direction {
@@ -236,10 +256,22 @@ impl Arrow {
         Size::new(marker_width, marker_height.max(stroke_width))
     }
 
-    fn render_to_svg(&self, source: Point, destination: Point) -> Box<dyn svg::Node> {
-        // Create path data based on arrow style
-        let path_data =
-            Self::create_path_data_for_style(source, destination, self.definition.style);
+    /// Renders this arrow to an SVG path element.
+    ///
+    /// Only [`ArrowStyle::Curved`] respects external `control_points`. When
+    /// no control points are provided, it falls back to a straight line.
+    /// Other styles (`Straight`, `Orthogonal`) ignore control points entirely.
+    fn render_to_svg(
+        &self,
+        source: Point,
+        destination: Point,
+        control_points: &[Point],
+    ) -> Box<dyn svg::Node> {
+        let path_data = match self.definition.style {
+            ArrowStyle::Curved => Self::curved_path_data(source, control_points, destination),
+            ArrowStyle::Straight => Self::straight_path_data(source, destination),
+            ArrowStyle::Orthogonal => Self::orthogonal_path_data(source, destination),
+        };
 
         let color = self.definition.stroke().color();
 
@@ -291,47 +323,79 @@ impl Arrow {
         }
     }
 
-    /// Create a path data string for the given arrow style
-    fn create_path_data_for_style(start: Point, end: Point, style: ArrowStyle) -> String {
-        match style {
-            ArrowStyle::Straight => Self::create_path_data_from_points(start, end),
-            ArrowStyle::Curved => Self::create_curved_path_data_from_points(start, end),
-            ArrowStyle::Orthogonal => Self::create_orthogonal_path_data_from_points(start, end),
+    /// Creates an SVG path data string from external control points.
+    ///
+    /// Returns a straight line if `control_points` is empty. Otherwise, the
+    /// slice length determines the curve type:
+    /// - 1 point: quadratic bezier (SVG `Q` command).
+    /// - 2 points: cubic bezier (SVG `C` command).
+    /// - 3+ points: chained cubic bezier segments with midpoint anchors.
+    ///
+    /// For 3+ points, control points are grouped into pairs. Each pair defines
+    /// one cubic bezier segment. Intermediate anchor points (where segments join)
+    /// are computed as midpoints between consecutive control points at segment
+    /// boundaries. If the count is odd, the final segment is a quadratic bezier.
+    ///
+    /// See [SVG curve commands](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#curve_commands)
+    /// for details on how bezier control points map to SVG path data.
+    fn curved_path_data(start: Point, control_points: &[Point], end: Point) -> String {
+        if control_points.is_empty() {
+            return Self::straight_path_data(start, end);
         }
+
+        let mut path = format!("M {} {}", start.x(), start.y());
+        let mut i = 0;
+        let len = control_points.len();
+
+        while i < len {
+            let remaining = len - i;
+            if remaining >= 2 {
+                let cp1 = control_points[i];
+                let cp2 = control_points[i + 1];
+                // Determine the endpoint of this segment
+                let segment_end = if i + 2 < len {
+                    // More points follow: anchor at midpoint between cp2 and next cp
+                    cp2.midpoint(control_points[i + 2])
+                } else {
+                    // Last pair: end at the destination
+                    end
+                };
+                path.push_str(&format!(
+                    " C {} {}, {} {}, {} {}",
+                    cp1.x(),
+                    cp1.y(),
+                    cp2.x(),
+                    cp2.y(),
+                    segment_end.x(),
+                    segment_end.y()
+                ));
+                i += 2;
+            } else {
+                // Odd trailing point: quadratic bezier to destination
+                let cp = control_points[i];
+                path.push_str(&format!(
+                    " Q {} {}, {} {}",
+                    cp.x(),
+                    cp.y(),
+                    end.x(),
+                    end.y()
+                ));
+                i += 1;
+            }
+        }
+
+        path
     }
 
-    /// Create a path data string from two points
-    pub fn create_path_data_from_points(start: Point, end: Point) -> String {
+    /// Creates a straight-line path data string from two points.
+    pub fn straight_path_data(start: Point, end: Point) -> String {
         format!("M {} {} L {} {}", start.x(), start.y(), end.x(), end.y())
     }
 
-    /// Create a curved path data string from two points
-    /// Creates a cubic bezier curve with control points positioned to create a nice arc
-    fn create_curved_path_data_from_points(start: Point, end: Point) -> String {
-        // For the control points, we'll use points positioned to create a smooth arc
-        // between the start and end points
-        let ctrl1_x = start.x() + (end.x() - start.x()) / 4.0;
-        let ctrl1_y = start.y() - (end.y() - start.y()) / 2.0;
-
-        let ctrl2_x = end.x() - (end.x() - start.x()) / 4.0;
-        let ctrl2_y = end.y() + (start.y() - end.y()) / 2.0;
-
-        format!(
-            "M {} {} C {} {}, {} {}, {} {}",
-            start.x(),
-            start.y(),
-            ctrl1_x,
-            ctrl1_y,
-            ctrl2_x,
-            ctrl2_y,
-            end.x(),
-            end.y()
-        )
-    }
-
-    /// Create an orthogonal path data string from two points
-    /// Creates a path with only horizontal and vertical line segments
-    fn create_orthogonal_path_data_from_points(start: Point, end: Point) -> String {
+    /// Creates an orthogonal path data string from two points.
+    ///
+    /// Produces a path with only horizontal and vertical line segments.
+    fn orthogonal_path_data(start: Point, end: Point) -> String {
         // Determine whether to go horizontal first then vertical, or vertical first then horizontal
         // This decision is based on the relative positions of the start and end points
 
@@ -506,12 +570,95 @@ mod tests {
     }
 
     #[test]
-    fn test_create_path_data_from_points() {
+    fn test_straight_path_data() {
         let start = Point::new(10.0, 20.0);
         let end = Point::new(100.0, 50.0);
 
-        let path = Arrow::create_path_data_from_points(start, end);
+        let path = Arrow::straight_path_data(start, end);
 
         assert_eq!(path, "M 10 20 L 100 50");
+    }
+
+    #[test]
+    fn test_curved_path_data_empty_falls_back_to_straight() {
+        let start = Point::new(0.0, 0.0);
+        let end = Point::new(100.0, 50.0);
+
+        // Empty control points should produce the same result as straight line
+        let path = Arrow::curved_path_data(start, &[], end);
+        assert_eq!(path, "M 0 0 L 100 50");
+    }
+
+    #[test]
+    fn test_curved_path_data_quadratic_bezier() {
+        let start = Point::new(0.0, 0.0);
+        let cp = Point::new(50.0, -30.0);
+        let end = Point::new(100.0, 0.0);
+
+        let path = Arrow::curved_path_data(start, &[cp], end);
+        assert_eq!(path, "M 0 0 Q 50 -30, 100 0");
+    }
+
+    #[test]
+    fn test_curved_path_data_cubic_bezier() {
+        let start = Point::new(0.0, 0.0);
+        let cp1 = Point::new(30.0, -40.0);
+        let cp2 = Point::new(70.0, -40.0);
+        let end = Point::new(100.0, 0.0);
+
+        let path = Arrow::curved_path_data(start, &[cp1, cp2], end);
+        assert_eq!(path, "M 0 0 C 30 -40, 70 -40, 100 0");
+    }
+
+    #[test]
+    fn test_curved_path_data_chained_cubic_even() {
+        // 4 control points = 2 cubic segments
+        let start = Point::new(0.0, 0.0);
+        let cp1 = Point::new(10.0, 20.0);
+        let cp2 = Point::new(30.0, 40.0);
+        let cp3 = Point::new(60.0, 40.0);
+        let cp4 = Point::new(80.0, 20.0);
+        let end = Point::new(100.0, 0.0);
+
+        let path = Arrow::curved_path_data(start, &[cp1, cp2, cp3, cp4], end);
+
+        // First segment: start -> midpoint(cp2, cp3) with cp1, cp2 as control points
+        // midpoint(30,40 and 60,40) = (45, 40)
+        // Second segment: midpoint -> end with cp3, cp4 as control points
+        assert_eq!(path, "M 0 0 C 10 20, 30 40, 45 40 C 60 40, 80 20, 100 0");
+    }
+
+    #[test]
+    fn test_curved_path_data_chained_odd() {
+        // 3 control points = 1 cubic segment + 1 quadratic segment
+        let start = Point::new(0.0, 0.0);
+        let cp1 = Point::new(20.0, -30.0);
+        let cp2 = Point::new(50.0, -30.0);
+        let cp3 = Point::new(80.0, -10.0);
+        let end = Point::new(100.0, 0.0);
+
+        let path = Arrow::curved_path_data(start, &[cp1, cp2, cp3], end);
+
+        // First segment: cubic with cp1, cp2, ending at midpoint(cp2, cp3) = (65, -20)
+        // Second segment: quadratic with cp3, ending at destination
+        assert_eq!(path, "M 0 0 C 20 -30, 50 -30, 65 -20 Q 80 -10, 100 0");
+    }
+
+    #[test]
+    fn test_draw_arrow_with_control_points() {
+        let mut drawer = ArrowDrawer::default();
+        let stroke = Rc::new(StrokeDefinition::default());
+        let def = Rc::new(ArrowDefinition::new(stroke));
+        let arrow = Arrow::new(def, ArrowDirection::Forward);
+
+        let source = Point::new(0.0, 0.0);
+        let destination = Point::new(100.0, 50.0);
+        let cp = Point::new(50.0, -20.0);
+
+        // Should not panic with control points
+        let _node = drawer.draw_arrow(&arrow, source, destination, &[cp]);
+
+        // Should also work with empty (fallback)
+        let _node = drawer.draw_arrow(&arrow, source, destination, &[]);
     }
 }

--- a/crates/orrery-core/src/draw/arrow_with_text.rs
+++ b/crates/orrery-core/src/draw/arrow_with_text.rs
@@ -4,7 +4,7 @@
 //! text along the arrow path.
 
 use crate::{
-    draw::{Arrow, ArrowDrawer, Drawable, LayeredOutput, RenderLayer, Text},
+    draw::{Arrow, ArrowDrawer, ArrowStyle, Drawable, LayeredOutput, RenderLayer, Text},
     geometry::{Point, Size},
 };
 
@@ -26,14 +26,37 @@ impl<'a> ArrowWithText<'a> {
 
     /// Calculates the position where text should be rendered relative to the arrow.
     ///
-    /// The text is positioned at the midpoint of the arrow line.
-    fn calculate_text_position(&self, source: Point, destination: Point) -> Point {
+    /// Only [`ArrowStyle::Curved`] uses control points for positioning. Other
+    /// styles always place text at the geometric midpoint of source and destination.
+    fn calculate_text_position(
+        &self,
+        source: Point,
+        destination: Point,
+        control_points: &[Point],
+    ) -> Point {
         if self.text.is_none() {
             return Point::zero();
         }
 
-        // Position text at the midpoint of the arrow
-        source.midpoint(destination)
+        if self.arrow.style() != ArrowStyle::Curved {
+            return source.midpoint(destination);
+        };
+
+        match control_points {
+            [] => source.midpoint(destination),
+            [cp] => quadratic_bezier_midpoint(source, *cp, destination),
+            [cp1, cp2] => cubic_bezier_midpoint(source, *cp1, *cp2, destination),
+            _ => {
+                // For chained curves, approximate by evaluating the midpoint
+                // of the middle segment's local neighborhood.
+                let mid_idx = control_points.len() / 2;
+                let mid_cp = control_points[mid_idx];
+                // unwrap_or cases are unreachable when control_points has 3+ elements.
+                let before = control_points.get(mid_idx - 1).unwrap_or(&source);
+                let after = control_points.get(mid_idx + 1).unwrap_or(&destination);
+                quadratic_bezier_midpoint(*before, mid_cp, *after)
+            }
+        }
     }
 
     /// Returns the minimum [`Size`] needed to render this arrow with its text.
@@ -45,20 +68,33 @@ impl<'a> ArrowWithText<'a> {
     }
 
     /// Renders the arrow with optional text to layered output.
+    ///
+    /// When `control_points` is non-empty, the arrow path follows the provided
+    /// bezier curve and the text label is positioned at the curve's visual
+    /// midpoint (t=0.5) rather than the geometric midpoint of the endpoints.
+    ///
+    /// # Arguments
+    ///
+    /// * `arrow_drawer` - Drawer that manages SVG marker generation.
+    /// * `source` - Starting point of the arrow.
+    /// * `destination` - Ending point of the arrow.
+    /// * `control_points` - Bezier control points. See [`ArrowDrawer::draw_arrow`].
     // TODO: borrowing arrow_drawer is not good in here.
     pub fn render_to_layers(
         &self,
         arrow_drawer: &mut ArrowDrawer,
         source: Point,
         destination: Point,
+        control_points: &[Point],
     ) -> LayeredOutput {
         let mut output = LayeredOutput::new();
 
-        let rendered_arrow = arrow_drawer.draw_arrow(&self.arrow, source, destination);
+        let rendered_arrow =
+            arrow_drawer.draw_arrow(&self.arrow, source, destination, control_points);
         output.add_to_layer(RenderLayer::Arrow, rendered_arrow);
 
         if let Some(text) = &self.text {
-            let text_pos = self.calculate_text_position(source, destination);
+            let text_pos = self.calculate_text_position(source, destination, control_points);
             let text_output = text.render_to_layers(text_pos);
             output.merge(text_output);
         }
@@ -79,25 +115,49 @@ impl<'a> ArrowWithText<'a> {
 pub struct ArrowWithTextDrawer(ArrowDrawer);
 
 impl ArrowWithTextDrawer {
-    /// Creates a new ArrowWithTextDrawer
+    /// Creates a new [`ArrowWithTextDrawer`].
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Adds an arrow with optional text to be rendered later
+    /// Draws an arrow with optional text and returns the layered output.
+    ///
+    /// # Arguments
+    ///
+    /// * `arrow_with_text` - The arrow and text composite to render.
+    /// * `source` - Starting point of the arrow.
+    /// * `destination` - Ending point of the arrow.
+    /// * `control_points` - Bezier control points. See [`ArrowDrawer::draw_arrow`].
     pub fn draw_arrow_with_text(
         &mut self,
         arrow_with_text: &ArrowWithText,
         source: Point,
         destination: Point,
+        control_points: &[Point],
     ) -> LayeredOutput {
-        arrow_with_text.render_to_layers(&mut self.0, source, destination)
+        arrow_with_text.render_to_layers(&mut self.0, source, destination, control_points)
     }
 
-    /// Generates SVG marker definitions for all arrows
+    /// Generates SVG marker definitions for all rendered arrows.
     pub fn draw_marker_definitions(&self) -> Box<dyn svg::Node> {
         self.0.draw_marker_definitions()
     }
+}
+
+/// Evaluates a quadratic bezier curve at t=0.5 (parametric midpoint).
+fn quadratic_bezier_midpoint(start: Point, cp: Point, end: Point) -> Point {
+    Point::new(
+        0.25 * start.x() + 0.5 * cp.x() + 0.25 * end.x(),
+        0.25 * start.y() + 0.5 * cp.y() + 0.25 * end.y(),
+    )
+}
+
+/// Evaluates a cubic bezier curve at t=0.5 (parametric midpoint).
+fn cubic_bezier_midpoint(start: Point, cp1: Point, cp2: Point, end: Point) -> Point {
+    Point::new(
+        0.125 * start.x() + 0.375 * cp1.x() + 0.375 * cp2.x() + 0.125 * end.x(),
+        0.125 * start.y() + 0.375 * cp1.y() + 0.375 * cp2.y() + 0.125 * end.y(),
+    )
 }
 
 #[cfg(test)]
@@ -112,6 +172,14 @@ mod tests {
         let stroke = Rc::new(StrokeDefinition::default());
         let definition = Rc::new(ArrowDefinition::new(stroke));
         Arrow::new(definition, direction)
+    }
+
+    /// Helper function to create a test arrow with a specific style.
+    fn create_test_arrow_with_style(direction: ArrowDirection, style: ArrowStyle) -> Arrow {
+        let stroke = Rc::new(StrokeDefinition::default());
+        let mut definition = ArrowDefinition::new(stroke);
+        definition.set_style(style);
+        Arrow::new(Rc::new(definition), direction)
     }
 
     #[test]
@@ -161,20 +229,93 @@ mod tests {
         let arrow = create_test_arrow(ArrowDirection::Forward);
         let arrow_with_text = ArrowWithText::new(arrow, None);
 
-        // Without text, should return default point
-        let pos =
-            arrow_with_text.calculate_text_position(Point::new(0.0, 0.0), Point::new(100.0, 100.0));
+        // Without text, should return zero point.
+        let pos = arrow_with_text.calculate_text_position(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 100.0),
+            &[],
+        );
         assert_eq!(pos, Point::zero());
 
-        // With text, should return midpoint
+        // With text and no control points, should return midpoint.
         let arrow = create_test_arrow(ArrowDirection::Forward);
         let text_def = TextDefinition::default();
         let text = Text::new(&text_def, "Label");
         let arrow_with_text = ArrowWithText::new(arrow, Some(text));
 
-        let pos =
-            arrow_with_text.calculate_text_position(Point::new(0.0, 0.0), Point::new(100.0, 50.0));
+        let pos = arrow_with_text.calculate_text_position(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 50.0),
+            &[],
+        );
         assert_eq!(pos, Point::new(50.0, 25.0));
+
+        // With text and quadratic control point
+        let arrow = create_test_arrow(ArrowDirection::Forward);
+        let text_def = TextDefinition::default();
+        let text = Text::new(&text_def, "Label");
+        let arrow_with_text = ArrowWithText::new(arrow, Some(text));
+
+        let cp = Point::new(50.0, -30.0);
+        let pos = arrow_with_text.calculate_text_position(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            &[cp],
+        );
+        // 0.25*0 + 0.5*50 + 0.25*100 = 50, 0.25*0 + 0.5*(-30) + 0.25*0 = -15
+        assert_eq!(pos, Point::new(50.0, -15.0));
+
+        // With text and cubic control points
+        let arrow = create_test_arrow(ArrowDirection::Forward);
+        let text_def = TextDefinition::default();
+        let text = Text::new(&text_def, "Label");
+        let arrow_with_text = ArrowWithText::new(arrow, Some(text));
+
+        let cp1 = Point::new(30.0, -40.0);
+        let cp2 = Point::new(70.0, -40.0);
+        let pos = arrow_with_text.calculate_text_position(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            &[cp1, cp2],
+        );
+        // 0.125*0 + 0.375*30 + 0.375*70 + 0.125*100 = 0+11.25+26.25+12.5 = 50
+        // 0.125*0 + 0.375*(-40) + 0.375*(-40) + 0.125*0 = -15-15 = -30
+        assert_eq!(pos, Point::new(50.0, -30.0));
+    }
+
+    #[test]
+    fn test_calculate_text_position_straight_ignores_control_points() {
+        let arrow = create_test_arrow_with_style(ArrowDirection::Forward, ArrowStyle::Straight);
+        let text_def = TextDefinition::default();
+        let text = Text::new(&text_def, "Label");
+        let arrow_with_text = ArrowWithText::new(arrow, Some(text));
+
+        // Even with control points, Straight style should use geometric midpoint
+        let cp = Point::new(50.0, -30.0);
+        let pos = arrow_with_text.calculate_text_position(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            &[cp],
+        );
+        assert_eq!(pos, Point::new(50.0, 0.0));
+    }
+
+    #[test]
+    fn test_calculate_text_position_orthogonal_ignores_control_points() {
+        let arrow = create_test_arrow_with_style(ArrowDirection::Forward, ArrowStyle::Orthogonal);
+        let text_def = TextDefinition::default();
+        let text = Text::new(&text_def, "Label");
+        let arrow_with_text = ArrowWithText::new(arrow, Some(text));
+
+        // Even with control points, Orthogonal style should use geometric midpoint
+        let cp1 = Point::new(30.0, -40.0);
+        let cp2 = Point::new(70.0, -40.0);
+        let pos = arrow_with_text.calculate_text_position(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            &[cp1, cp2],
+        );
+        assert_eq!(pos, Point::new(50.0, 0.0));
     }
 
     #[test]
@@ -197,20 +338,22 @@ mod tests {
         let source = Point::new(0.0, 0.0);
         let destination = Point::new(100.0, 50.0);
 
-        // With text label - should have arrow and text layers
+        // With text label and control points
         let arrow = create_test_arrow(ArrowDirection::Forward);
         let text_def = TextDefinition::default();
         let text = Text::new(&text_def, "Label");
         let arrow_with_text = ArrowWithText::new(arrow, Some(text));
+        let cp = Point::new(50.0, -20.0);
 
-        let output = arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination);
+        let output =
+            arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination, &[cp]);
         assert!(!output.is_empty());
 
         // Without text label - should still have arrow layer
         let arrow = create_test_arrow(ArrowDirection::Forward);
         let arrow_with_text = ArrowWithText::new(arrow, None);
 
-        let output = arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination);
+        let output = arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination, &[]);
         assert!(!output.is_empty());
     }
 
@@ -233,12 +376,67 @@ mod tests {
             let text = Text::new(&text_def, "Label");
             let arrow_with_text = ArrowWithText::new(arrow, Some(text));
 
-            let output = arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination);
+            let output =
+                arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination, &[]);
             assert!(
                 !output.is_empty(),
                 "Rendering failed for direction: {:?}",
                 direction
             );
         }
+    }
+
+    #[test]
+    fn test_quadratic_bezier_midpoint() {
+        // Symmetric curve: midpoint should be directly above the line midpoint
+        let start = Point::new(0.0, 0.0);
+        let cp = Point::new(50.0, -60.0);
+        let end = Point::new(100.0, 0.0);
+
+        let mid = quadratic_bezier_midpoint(start, cp, end);
+        // 0.25*0 + 0.5*50 + 0.25*100 = 50
+        // 0.25*0 + 0.5*(-60) + 0.25*0 = -30
+        assert_eq!(mid, Point::new(50.0, -30.0));
+
+        // Control point on the line: midpoint should equal the straight midpoint
+        let cp_on_line = Point::new(50.0, 25.0);
+        let mid = quadratic_bezier_midpoint(start, cp_on_line, Point::new(100.0, 50.0));
+        // 0.25*0 + 0.5*50 + 0.25*100 = 50
+        // 0.25*0 + 0.5*25 + 0.25*50 = 25
+        assert_eq!(mid, Point::new(50.0, 25.0));
+
+        // Degenerate: all points the same
+        let p = Point::new(10.0, 20.0);
+        let mid = quadratic_bezier_midpoint(p, p, p);
+        assert_eq!(mid, p);
+    }
+
+    #[test]
+    fn test_cubic_bezier_midpoint() {
+        // Symmetric S-curve
+        let start = Point::new(0.0, 0.0);
+        let cp1 = Point::new(30.0, -40.0);
+        let cp2 = Point::new(70.0, -40.0);
+        let end = Point::new(100.0, 0.0);
+
+        let mid = cubic_bezier_midpoint(start, cp1, cp2, end);
+        // 0.125*0 + 0.375*30 + 0.375*70 + 0.125*100 = 11.25 + 26.25 + 12.5 = 50
+        // 0.125*0 + 0.375*(-40) + 0.375*(-40) + 0.125*0 = -15 + -15 = -30
+        assert_eq!(mid, Point::new(50.0, -30.0));
+
+        // Control points on the line: should equal straight midpoint
+        let start = Point::new(0.0, 0.0);
+        let end = Point::new(100.0, 100.0);
+        let cp1 = Point::new(25.0, 25.0);
+        let cp2 = Point::new(75.0, 75.0);
+
+        let mid = cubic_bezier_midpoint(start, cp1, cp2, end);
+        // 0.125*0 + 0.375*25 + 0.375*75 + 0.125*100 = 9.375 + 28.125 + 12.5 = 50
+        assert_eq!(mid, Point::new(50.0, 50.0));
+
+        // Degenerate: all points the same
+        let p = Point::new(5.0, 5.0);
+        let mid = cubic_bezier_midpoint(p, p, p, p);
+        assert_eq!(mid, p);
     }
 }

--- a/crates/orrery/src/export/svg/component.rs
+++ b/crates/orrery/src/export/svg/component.rs
@@ -35,8 +35,12 @@ impl Svg {
         let source_edge = self.find_intersection(source, target.position());
         let target_edge = self.find_intersection(target, source.position());
 
-        self.arrow_with_text_drawer
-            .draw_arrow_with_text(arrow_with_text, source_edge, target_edge)
+        self.arrow_with_text_drawer.draw_arrow_with_text(
+            arrow_with_text,
+            source_edge,
+            target_edge,
+            &[],
+        )
     }
 
     pub fn calculate_component_diagram_bounds(

--- a/crates/orrery/src/export/svg/sequence.rs
+++ b/crates/orrery/src/export/svg/sequence.rs
@@ -60,6 +60,7 @@ impl Svg {
             message.arrow_with_text(),
             start_point,
             end_point,
+            &[],
         )
     }
 


### PR DESCRIPTION
## Summary

Add `control_points: &[Point]` parameter to the arrow rendering chain, allowing a routing phase to provide pre-computed bezier curves. Only `ArrowStyle::Curved` uses them — `Straight` and `Orthogonal` ignore them entirely.

When no control points are provided, `Curved` falls back to a straight line (removes the old internal curve generation that invented its own CPs). The default `ArrowStyle` is changed from `Straight` to `Curved`.

Text positioning evaluates the bezier at t=0.5 for accurate label placement on curves, respecting the arrow's style.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #106
