### PR TITLE
feat(draw)!: arrows carry their geometric path from layout to rendering

### DIFF
--- a/crates/orrery-core/src/draw.rs
+++ b/crates/orrery-core/src/draw.rs
@@ -23,8 +23,8 @@ mod text;
 mod text_positioning;
 
 pub use activation_box::{ActivationBox, ActivationBoxDefinition};
-pub use arrow::{Arrow, ArrowDefinition, ArrowDirection, ArrowDrawer, ArrowStyle};
-pub use arrow_with_text::{ArrowWithText, ArrowWithTextDrawer};
+pub use arrow::{Arrow, ArrowDefinition, ArrowDirection, ArrowDrawer, ArrowPath, ArrowStyle};
+pub use arrow_with_text::{ArrowWithText, ArrowWithTextDrawer, PositionedArrowWithText};
 pub use fragment::{Fragment, FragmentDefinition, FragmentSection};
 pub use layer::{LayeredOutput, RenderLayer};
 pub use lifeline::{Lifeline, LifelineDefinition};

--- a/crates/orrery-core/src/draw/arrow.rs
+++ b/crates/orrery-core/src/draw/arrow.rs
@@ -153,6 +153,79 @@ impl fmt::Display for ArrowDirection {
     }
 }
 
+/// The geometric path of an arrow: source, destination, and optional control points.
+///
+/// For straight arrows, `control_points` is empty. For curved arrows (bezier paths),
+/// `control_points` contains the intermediate curve points.
+///
+/// # Examples
+///
+/// ```
+/// # use orrery_core::geometry::Point;
+/// # use orrery_core::draw::ArrowPath;
+/// // A straight arrow from (0,0) to (100,50)
+/// let path = ArrowPath::straight(Point::new(0.0, 0.0), Point::new(100.0, 50.0));
+///
+/// // A curved arrow with one control point (quadratic bezier)
+/// let curved = ArrowPath::new(
+///     Point::new(0.0, 0.0),
+///     Point::new(100.0, 0.0),
+///     vec![Point::new(50.0, -30.0)],
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArrowPath {
+    source: Point,
+    destination: Point,
+    control_points: Vec<Point>,
+}
+
+impl ArrowPath {
+    /// Creates a new arrow path.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - The starting point of the arrow.
+    /// * `destination` - The ending point of the arrow.
+    /// * `control_points` - Bezier control points for curved paths. Empty for straight arrows.
+    pub fn new(source: Point, destination: Point, control_points: Vec<Point>) -> Self {
+        Self {
+            source,
+            destination,
+            control_points,
+        }
+    }
+
+    /// Creates a straight arrow path.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - The starting point of the arrow.
+    /// * `destination` - The ending point of the arrow.
+    pub fn straight(source: Point, destination: Point) -> Self {
+        Self {
+            source,
+            destination,
+            control_points: Vec::new(),
+        }
+    }
+
+    /// Returns the starting point of the arrow.
+    pub fn source(&self) -> Point {
+        self.source
+    }
+
+    /// Returns the ending point of the arrow.
+    pub fn destination(&self) -> Point {
+        self.destination
+    }
+
+    /// Returns the control points for curved paths.
+    pub fn control_points(&self) -> &[Point] {
+        &self.control_points
+    }
+}
+
 /// A drawable arrow with styling and direction markers.
 ///
 /// An Arrow combines an `ArrowDefinition` (containing visual properties
@@ -176,30 +249,18 @@ pub struct ArrowDrawer {
 }
 
 impl ArrowDrawer {
-    /// Draws an arrow between two points and collects its color for marker generation.
+    /// Draws an arrow and collects its color for marker generation.
     ///
-    /// Only arrows with [`ArrowStyle::Curved`] use the provided `control_points`.
+    /// Only arrows with [`ArrowStyle::Curved`] use the path's control points.
     /// Other styles ([`ArrowStyle::Straight`], [`ArrowStyle::Orthogonal`]) ignore them entirely.
     ///
     /// # Arguments
     ///
     /// * `arrow` - The arrow to render.
-    /// * `source` - Starting point of the arrow.
-    /// * `destination` - Ending point of the arrow.
-    /// * `control_points` - Bezier control points for [`ArrowStyle::Curved`] arrows.
-    ///   - `[]` — falls back to a straight line.
-    ///   - `[cp]` — quadratic bezier curve.
-    ///   - `[cp1, cp2]` — cubic bezier curve.
-    ///   - 3+ points — chained cubic bezier segments with midpoint anchors.
-    pub fn draw_arrow(
-        &mut self,
-        arrow: &Arrow,
-        source: Point,
-        destination: Point,
-        control_points: &[Point],
-    ) -> Box<dyn svg::Node> {
+    /// * `path` - The geometric path of the arrow.
+    pub fn draw_arrow(&mut self, arrow: &Arrow, path: &ArrowPath) -> Box<dyn svg::Node> {
         self.register_arrow_markers(arrow);
-        arrow.render_to_svg(source, destination, control_points)
+        arrow.render_to_svg(path)
     }
 
     /// Generates SVG marker definitions for all collected arrow colors.
@@ -261,16 +322,11 @@ impl Arrow {
     /// Only [`ArrowStyle::Curved`] respects external `control_points`. When
     /// no control points are provided, it falls back to a straight line.
     /// Other styles (`Straight`, `Orthogonal`) ignore control points entirely.
-    fn render_to_svg(
-        &self,
-        source: Point,
-        destination: Point,
-        control_points: &[Point],
-    ) -> Box<dyn svg::Node> {
+    fn render_to_svg(&self, path: &ArrowPath) -> Box<dyn svg::Node> {
         let path_data = match self.definition.style {
-            ArrowStyle::Curved => Self::curved_path_data(source, control_points, destination),
-            ArrowStyle::Straight => Self::straight_path_data(source, destination),
-            ArrowStyle::Orthogonal => Self::orthogonal_path_data(source, destination),
+            ArrowStyle::Curved => Self::curved_path_data(path),
+            ArrowStyle::Straight => Self::straight_path_data(path.source(), path.destination()),
+            ArrowStyle::Orthogonal => Self::orthogonal_path_data(path.source(), path.destination()),
         };
 
         let color = self.definition.stroke().color();
@@ -338,12 +394,14 @@ impl Arrow {
     ///
     /// See [SVG curve commands](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#curve_commands)
     /// for details on how bezier control points map to SVG path data.
-    fn curved_path_data(start: Point, control_points: &[Point], end: Point) -> String {
-        if control_points.is_empty() {
-            return Self::straight_path_data(start, end);
+    fn curved_path_data(path: &ArrowPath) -> String {
+        if path.control_points().is_empty() {
+            return Self::straight_path_data(path.source(), path.destination());
         }
 
-        let mut path = format!("M {} {}", start.x(), start.y());
+        let control_points = path.control_points();
+        let end = path.destination();
+        let mut d = format!("M {} {}", path.source().x(), path.source().y());
         let mut i = 0;
         let len = control_points.len();
 
@@ -360,7 +418,7 @@ impl Arrow {
                     // Last pair: end at the destination
                     end
                 };
-                path.push_str(&format!(
+                d.push_str(&format!(
                     " C {} {}, {} {}, {} {}",
                     cp1.x(),
                     cp1.y(),
@@ -373,7 +431,7 @@ impl Arrow {
             } else {
                 // Odd trailing point: quadratic bezier to destination
                 let cp = control_points[i];
-                path.push_str(&format!(
+                d.push_str(&format!(
                     " Q {} {}, {} {}",
                     cp.x(),
                     cp.y(),
@@ -384,7 +442,7 @@ impl Arrow {
             }
         }
 
-        path
+        d
     }
 
     /// Creates a straight-line path data string from two points.
@@ -581,67 +639,76 @@ mod tests {
 
     #[test]
     fn test_curved_path_data_empty_falls_back_to_straight() {
-        let start = Point::new(0.0, 0.0);
-        let end = Point::new(100.0, 50.0);
+        let path = ArrowPath::straight(Point::new(0.0, 0.0), Point::new(100.0, 50.0));
 
-        // Empty control points should produce the same result as straight line
-        let path = Arrow::curved_path_data(start, &[], end);
-        assert_eq!(path, "M 0 0 L 100 50");
+        let result = Arrow::curved_path_data(&path);
+        assert_eq!(result, "M 0 0 L 100 50");
     }
 
     #[test]
     fn test_curved_path_data_quadratic_bezier() {
-        let start = Point::new(0.0, 0.0);
-        let cp = Point::new(50.0, -30.0);
-        let end = Point::new(100.0, 0.0);
+        let path = ArrowPath::new(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            vec![Point::new(50.0, -30.0)],
+        );
 
-        let path = Arrow::curved_path_data(start, &[cp], end);
-        assert_eq!(path, "M 0 0 Q 50 -30, 100 0");
+        let result = Arrow::curved_path_data(&path);
+        assert_eq!(result, "M 0 0 Q 50 -30, 100 0");
     }
 
     #[test]
     fn test_curved_path_data_cubic_bezier() {
-        let start = Point::new(0.0, 0.0);
-        let cp1 = Point::new(30.0, -40.0);
-        let cp2 = Point::new(70.0, -40.0);
-        let end = Point::new(100.0, 0.0);
+        let path = ArrowPath::new(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            vec![Point::new(30.0, -40.0), Point::new(70.0, -40.0)],
+        );
 
-        let path = Arrow::curved_path_data(start, &[cp1, cp2], end);
-        assert_eq!(path, "M 0 0 C 30 -40, 70 -40, 100 0");
+        let result = Arrow::curved_path_data(&path);
+        assert_eq!(result, "M 0 0 C 30 -40, 70 -40, 100 0");
     }
 
     #[test]
     fn test_curved_path_data_chained_cubic_even() {
         // 4 control points = 2 cubic segments
-        let start = Point::new(0.0, 0.0);
-        let cp1 = Point::new(10.0, 20.0);
-        let cp2 = Point::new(30.0, 40.0);
-        let cp3 = Point::new(60.0, 40.0);
-        let cp4 = Point::new(80.0, 20.0);
-        let end = Point::new(100.0, 0.0);
+        let path = ArrowPath::new(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            vec![
+                Point::new(10.0, 20.0),
+                Point::new(30.0, 40.0),
+                Point::new(60.0, 40.0),
+                Point::new(80.0, 20.0),
+            ],
+        );
 
-        let path = Arrow::curved_path_data(start, &[cp1, cp2, cp3, cp4], end);
+        let result = Arrow::curved_path_data(&path);
 
         // First segment: start -> midpoint(cp2, cp3) with cp1, cp2 as control points
         // midpoint(30,40 and 60,40) = (45, 40)
         // Second segment: midpoint -> end with cp3, cp4 as control points
-        assert_eq!(path, "M 0 0 C 10 20, 30 40, 45 40 C 60 40, 80 20, 100 0");
+        assert_eq!(result, "M 0 0 C 10 20, 30 40, 45 40 C 60 40, 80 20, 100 0");
     }
 
     #[test]
     fn test_curved_path_data_chained_odd() {
         // 3 control points = 1 cubic segment + 1 quadratic segment
-        let start = Point::new(0.0, 0.0);
-        let cp1 = Point::new(20.0, -30.0);
-        let cp2 = Point::new(50.0, -30.0);
-        let cp3 = Point::new(80.0, -10.0);
-        let end = Point::new(100.0, 0.0);
+        let path = ArrowPath::new(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            vec![
+                Point::new(20.0, -30.0),
+                Point::new(50.0, -30.0),
+                Point::new(80.0, -10.0),
+            ],
+        );
 
-        let path = Arrow::curved_path_data(start, &[cp1, cp2, cp3], end);
+        let result = Arrow::curved_path_data(&path);
 
         // First segment: cubic with cp1, cp2, ending at midpoint(cp2, cp3) = (65, -20)
         // Second segment: quadratic with cp3, ending at destination
-        assert_eq!(path, "M 0 0 C 20 -30, 50 -30, 65 -20 Q 80 -10, 100 0");
+        assert_eq!(result, "M 0 0 C 20 -30, 50 -30, 65 -20 Q 80 -10, 100 0");
     }
 
     #[test]
@@ -656,9 +723,11 @@ mod tests {
         let cp = Point::new(50.0, -20.0);
 
         // Should not panic with control points
-        let _node = drawer.draw_arrow(&arrow, source, destination, &[cp]);
+        let path = ArrowPath::new(source, destination, vec![cp]);
+        let _node = drawer.draw_arrow(&arrow, &path);
 
         // Should also work with empty (fallback)
-        let _node = drawer.draw_arrow(&arrow, source, destination, &[]);
+        let path = ArrowPath::straight(source, destination);
+        let _node = drawer.draw_arrow(&arrow, &path);
     }
 }

--- a/crates/orrery-core/src/draw/arrow_with_text.rs
+++ b/crates/orrery-core/src/draw/arrow_with_text.rs
@@ -4,7 +4,7 @@
 //! text along the arrow path.
 
 use crate::{
-    draw::{Arrow, ArrowDrawer, ArrowStyle, Drawable, LayeredOutput, RenderLayer, Text},
+    draw::{Arrow, ArrowDrawer, ArrowPath, ArrowStyle, Drawable, LayeredOutput, RenderLayer, Text},
     geometry::{Point, Size},
 };
 
@@ -28,20 +28,19 @@ impl<'a> ArrowWithText<'a> {
     ///
     /// Only [`ArrowStyle::Curved`] uses control points for positioning. Other
     /// styles always place text at the geometric midpoint of source and destination.
-    fn calculate_text_position(
-        &self,
-        source: Point,
-        destination: Point,
-        control_points: &[Point],
-    ) -> Point {
+    fn calculate_text_position(&self, path: &ArrowPath) -> Point {
         if self.text.is_none() {
             return Point::zero();
         }
+
+        let source = path.source();
+        let destination = path.destination();
 
         if self.arrow.style() != ArrowStyle::Curved {
             return source.midpoint(destination);
         };
 
+        let control_points = path.control_points();
         match control_points {
             [] => source.midpoint(destination),
             [cp] => quadratic_bezier_midpoint(source, *cp, destination),
@@ -69,32 +68,27 @@ impl<'a> ArrowWithText<'a> {
 
     /// Renders the arrow with optional text to layered output.
     ///
-    /// When `control_points` is non-empty, the arrow path follows the provided
+    /// When control points are present in `path`, the arrow follows the provided
     /// bezier curve and the text label is positioned at the curve's visual
     /// midpoint (t=0.5) rather than the geometric midpoint of the endpoints.
     ///
     /// # Arguments
     ///
     /// * `arrow_drawer` - Drawer that manages SVG marker generation.
-    /// * `source` - Starting point of the arrow.
-    /// * `destination` - Ending point of the arrow.
-    /// * `control_points` - Bezier control points. See [`ArrowDrawer::draw_arrow`].
+    /// * `path` - The geometric path of the arrow.
     // TODO: borrowing arrow_drawer is not good in here.
     pub fn render_to_layers(
         &self,
         arrow_drawer: &mut ArrowDrawer,
-        source: Point,
-        destination: Point,
-        control_points: &[Point],
+        path: &ArrowPath,
     ) -> LayeredOutput {
         let mut output = LayeredOutput::new();
 
-        let rendered_arrow =
-            arrow_drawer.draw_arrow(&self.arrow, source, destination, control_points);
+        let rendered_arrow = arrow_drawer.draw_arrow(&self.arrow, path);
         output.add_to_layer(RenderLayer::Arrow, rendered_arrow);
 
         if let Some(text) = &self.text {
-            let text_pos = self.calculate_text_position(source, destination, control_points);
+            let text_pos = self.calculate_text_position(path);
             let text_output = text.render_to_layers(text_pos);
             output.merge(text_output);
         }
@@ -125,22 +119,49 @@ impl ArrowWithTextDrawer {
     /// # Arguments
     ///
     /// * `arrow_with_text` - The arrow and text composite to render.
-    /// * `source` - Starting point of the arrow.
-    /// * `destination` - Ending point of the arrow.
-    /// * `control_points` - Bezier control points. See [`ArrowDrawer::draw_arrow`].
+    /// * `path` - The geometric path of the arrow.
     pub fn draw_arrow_with_text(
         &mut self,
         arrow_with_text: &ArrowWithText,
-        source: Point,
-        destination: Point,
-        control_points: &[Point],
+        path: &ArrowPath,
     ) -> LayeredOutput {
-        arrow_with_text.render_to_layers(&mut self.0, source, destination, control_points)
+        arrow_with_text.render_to_layers(&mut self.0, path)
     }
 
     /// Generates SVG marker definitions for all rendered arrows.
     pub fn draw_marker_definitions(&self) -> Box<dyn svg::Node> {
         self.0.draw_marker_definitions()
+    }
+}
+
+/// An [`ArrowWithText`] paired with its [`ArrowPath`].
+#[derive(Debug, Clone)]
+pub struct PositionedArrowWithText<'a> {
+    arrow_with_text: ArrowWithText<'a>,
+    path: ArrowPath,
+}
+
+impl<'a> PositionedArrowWithText<'a> {
+    /// Creates a new positioned arrow with text.
+    ///
+    /// # Arguments
+    ///
+    /// * `arrow_with_text` - The visual definition of the arrow.
+    /// * `path` - The geometric path of the arrow.
+    pub fn new(arrow_with_text: ArrowWithText<'a>, path: ArrowPath) -> Self {
+        Self {
+            arrow_with_text,
+            path,
+        }
+    }
+
+    /// Renders this positioned arrow to layered SVG output.
+    ///
+    /// # Arguments
+    ///
+    /// * `drawer` - Manages arrow rendering and SVG marker generation.
+    pub fn render_to_layers(&self, drawer: &mut ArrowWithTextDrawer) -> LayeredOutput {
+        drawer.draw_arrow_with_text(&self.arrow_with_text, &self.path)
     }
 }
 
@@ -230,11 +251,8 @@ mod tests {
         let arrow_with_text = ArrowWithText::new(arrow, None);
 
         // Without text, should return zero point.
-        let pos = arrow_with_text.calculate_text_position(
-            Point::new(0.0, 0.0),
-            Point::new(100.0, 100.0),
-            &[],
-        );
+        let path = ArrowPath::straight(Point::new(0.0, 0.0), Point::new(100.0, 100.0));
+        let pos = arrow_with_text.calculate_text_position(&path);
         assert_eq!(pos, Point::zero());
 
         // With text and no control points, should return midpoint.
@@ -243,11 +261,8 @@ mod tests {
         let text = Text::new(&text_def, "Label");
         let arrow_with_text = ArrowWithText::new(arrow, Some(text));
 
-        let pos = arrow_with_text.calculate_text_position(
-            Point::new(0.0, 0.0),
-            Point::new(100.0, 50.0),
-            &[],
-        );
+        let path = ArrowPath::straight(Point::new(0.0, 0.0), Point::new(100.0, 50.0));
+        let pos = arrow_with_text.calculate_text_position(&path);
         assert_eq!(pos, Point::new(50.0, 25.0));
 
         // With text and quadratic control point
@@ -256,12 +271,12 @@ mod tests {
         let text = Text::new(&text_def, "Label");
         let arrow_with_text = ArrowWithText::new(arrow, Some(text));
 
-        let cp = Point::new(50.0, -30.0);
-        let pos = arrow_with_text.calculate_text_position(
+        let path = ArrowPath::new(
             Point::new(0.0, 0.0),
             Point::new(100.0, 0.0),
-            &[cp],
+            vec![Point::new(50.0, -30.0)],
         );
+        let pos = arrow_with_text.calculate_text_position(&path);
         // 0.25*0 + 0.5*50 + 0.25*100 = 50, 0.25*0 + 0.5*(-30) + 0.25*0 = -15
         assert_eq!(pos, Point::new(50.0, -15.0));
 
@@ -271,13 +286,12 @@ mod tests {
         let text = Text::new(&text_def, "Label");
         let arrow_with_text = ArrowWithText::new(arrow, Some(text));
 
-        let cp1 = Point::new(30.0, -40.0);
-        let cp2 = Point::new(70.0, -40.0);
-        let pos = arrow_with_text.calculate_text_position(
+        let path = ArrowPath::new(
             Point::new(0.0, 0.0),
             Point::new(100.0, 0.0),
-            &[cp1, cp2],
+            vec![Point::new(30.0, -40.0), Point::new(70.0, -40.0)],
         );
+        let pos = arrow_with_text.calculate_text_position(&path);
         // 0.125*0 + 0.375*30 + 0.375*70 + 0.125*100 = 0+11.25+26.25+12.5 = 50
         // 0.125*0 + 0.375*(-40) + 0.375*(-40) + 0.125*0 = -15-15 = -30
         assert_eq!(pos, Point::new(50.0, -30.0));
@@ -291,12 +305,12 @@ mod tests {
         let arrow_with_text = ArrowWithText::new(arrow, Some(text));
 
         // Even with control points, Straight style should use geometric midpoint
-        let cp = Point::new(50.0, -30.0);
-        let pos = arrow_with_text.calculate_text_position(
+        let path = ArrowPath::new(
             Point::new(0.0, 0.0),
             Point::new(100.0, 0.0),
-            &[cp],
+            vec![Point::new(50.0, -30.0)],
         );
+        let pos = arrow_with_text.calculate_text_position(&path);
         assert_eq!(pos, Point::new(50.0, 0.0));
     }
 
@@ -308,13 +322,12 @@ mod tests {
         let arrow_with_text = ArrowWithText::new(arrow, Some(text));
 
         // Even with control points, Orthogonal style should use geometric midpoint
-        let cp1 = Point::new(30.0, -40.0);
-        let cp2 = Point::new(70.0, -40.0);
-        let pos = arrow_with_text.calculate_text_position(
+        let path = ArrowPath::new(
             Point::new(0.0, 0.0),
             Point::new(100.0, 0.0),
-            &[cp1, cp2],
+            vec![Point::new(30.0, -40.0), Point::new(70.0, -40.0)],
         );
+        let pos = arrow_with_text.calculate_text_position(&path);
         assert_eq!(pos, Point::new(50.0, 0.0));
     }
 
@@ -345,15 +358,16 @@ mod tests {
         let arrow_with_text = ArrowWithText::new(arrow, Some(text));
         let cp = Point::new(50.0, -20.0);
 
-        let output =
-            arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination, &[cp]);
+        let path = ArrowPath::new(source, destination, vec![cp]);
+        let output = arrow_with_text.render_to_layers(&mut arrow_drawer, &path);
         assert!(!output.is_empty());
 
         // Without text label - should still have arrow layer
         let arrow = create_test_arrow(ArrowDirection::Forward);
         let arrow_with_text = ArrowWithText::new(arrow, None);
 
-        let output = arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination, &[]);
+        let path = ArrowPath::straight(source, destination);
+        let output = arrow_with_text.render_to_layers(&mut arrow_drawer, &path);
         assert!(!output.is_empty());
     }
 
@@ -376,8 +390,8 @@ mod tests {
             let text = Text::new(&text_def, "Label");
             let arrow_with_text = ArrowWithText::new(arrow, Some(text));
 
-            let output =
-                arrow_with_text.render_to_layers(&mut arrow_drawer, source, destination, &[]);
+            let path = ArrowPath::straight(source, destination);
+            let output = arrow_with_text.render_to_layers(&mut arrow_drawer, &path);
             assert!(
                 !output.is_empty(),
                 "Rendering failed for direction: {:?}",

--- a/crates/orrery/src/export/svg/component.rs
+++ b/crates/orrery/src/export/svg/component.rs
@@ -2,45 +2,21 @@
 
 use orrery_core::{
     draw::{self, LayeredOutput},
-    geometry::{Bounds, Point},
+    geometry::Bounds,
 };
 
 use super::Svg;
 use crate::{layout::component, layout::layer::ContentStack};
 
 impl Svg {
-    // Find the point where a line from the shape entity to an external point intersects with the shape entity's boundary
-    fn find_intersection(
-        &self,
-        shape_entity: &component::Component,
-        external_point: Point,
-    ) -> Point {
-        shape_entity
-            .drawable()
-            .inner()
-            .find_intersection(shape_entity.position(), external_point)
-    }
-
+    /// Renders a positioned component to layered SVG output.
     pub fn render_component(&self, component: &component::Component) -> LayeredOutput {
         component.drawable().render_to_layers()
     }
 
-    pub fn render_relation(
-        &mut self,
-        source: &component::Component,
-        target: &component::Component,
-        arrow_with_text: &draw::ArrowWithText,
-    ) -> LayeredOutput {
-        // Calculate intersection points where the line meets each shape's boundary
-        let source_edge = self.find_intersection(source, target.position());
-        let target_edge = self.find_intersection(target, source.position());
-
-        self.arrow_with_text_drawer.draw_arrow_with_text(
-            arrow_with_text,
-            source_edge,
-            target_edge,
-            &[],
-        )
+    /// Renders a positioned relation arrow to layered SVG output.
+    pub fn render_relation(&mut self, relation: &draw::PositionedArrowWithText) -> LayeredOutput {
+        relation.render_to_layers(&mut self.arrow_with_text_drawer)
     }
 
     pub fn calculate_component_diagram_bounds(

--- a/crates/orrery/src/export/svg/layer.rs
+++ b/crates/orrery/src/export/svg/layer.rs
@@ -240,11 +240,7 @@ impl Svg {
 
         // Render all relations within this positioned content
         for relation in content.relations() {
-            let relation_output = self.render_relation(
-                content.source(relation),
-                content.target(relation),
-                relation.arrow_with_text(),
-            );
+            let relation_output = self.render_relation(relation);
             output.merge(relation_output);
         }
 
@@ -285,7 +281,7 @@ impl Svg {
 
         // Render all messages within this positioned content
         for message in content.messages() {
-            let message_output = self.render_message(message, content);
+            let message_output = self.render_message(message);
             output.merge(message_output);
         }
 

--- a/crates/orrery/src/export/svg/sequence.rs
+++ b/crates/orrery/src/export/svg/sequence.rs
@@ -2,13 +2,14 @@
 
 use orrery_core::{
     draw::{self, Drawable as _, LayeredOutput},
-    geometry::{Bounds, Point},
+    geometry::Bounds,
 };
 
 use super::Svg;
 use crate::layout::{layer::ContentStack, sequence};
 
 impl Svg {
+    /// Renders a sequence diagram participant to layered SVG output.
     pub fn render_participant(&self, participant: &sequence::Participant) -> LayeredOutput {
         let mut output = LayeredOutput::new();
         let component = participant.component();
@@ -24,44 +25,9 @@ impl Svg {
         output
     }
 
-    pub fn render_message(
-        &mut self,
-        message: &sequence::Message,
-        layout: &sequence::Layout,
-    ) -> LayeredOutput {
-        let source = &layout.participants()[&message.source()];
-        let target = &layout.participants()[&message.target()];
-        let message_y = message.y_position();
-
-        // Calculate source X coordinate with activation box intersection if active
-        let source_x = sequence::calculate_message_endpoint_x(
-            layout.activations(),
-            source.component(),
-            message.source(),
-            message_y,
-            target.component().position().x(), // Use target center X for direction detection
-        );
-
-        // Calculate target X coordinate with activation box intersection if active
-        let target_x = sequence::calculate_message_endpoint_x(
-            layout.activations(),
-            target.component(),
-            message.target(),
-            message_y,
-            source.component().position().x(), // Use source center X for direction detection
-        );
-
-        // Create points for the message line (Y coordinate unchanged)
-        let start_point = Point::new(source_x, message_y);
-        let end_point = Point::new(target_x, message_y);
-
-        // Use the arrow_with_text from the message
-        self.arrow_with_text_drawer.draw_arrow_with_text(
-            message.arrow_with_text(),
-            start_point,
-            end_point,
-            &[],
-        )
+    /// Renders a positioned message arrow to layered SVG output.
+    pub fn render_message(&mut self, message: &draw::PositionedArrowWithText) -> LayeredOutput {
+        message.render_to_layers(&mut self.arrow_with_text_drawer)
     }
 
     /// Renders a fragment box in a sequence diagram.

--- a/crates/orrery/src/layout/component.rs
+++ b/crates/orrery/src/layout/component.rs
@@ -7,8 +7,12 @@
 //! # Types
 //!
 //! - [`Component`] - A positioned diagram element with bounds
-//! - [`LayoutRelation`] - A relation between components carrying layout-specific data
 //! - [`Layout`] - A complete layout of components and their connecting relations
+//!
+//! # Functions
+//!
+//! - [`positioned_arrow_from_relation`] - Constructs a positioned arrow from a semantic relation
+//! - [`adjust_positioned_contents_offset`] - Adjusts nested content offsets based on containment
 
 use std::{collections::HashMap, rc::Rc};
 
@@ -64,7 +68,7 @@ impl<'a> Component<'a> {
         self.drawable.position()
     }
 
-    /// Calculates the bounds of this component
+    /// Calculates the bounds of this component.
     ///
     /// The position is treated as the center of the component,
     /// and the bounds extend half the width/height in each direction.
@@ -77,54 +81,53 @@ impl<'a> Component<'a> {
     pub fn node_id(&self) -> Id {
         self.node_id
     }
-}
 
-/// A relation (connection) in a component layout with positional information.
-///
-/// LayoutRelation wraps an AST relation with additional layout-specific data,
-/// including the indices of the source and target components within the layout.
-/// This allows the layout system to efficiently reference components when
-/// positioning and rendering relations.
-#[derive(Debug, Clone)]
-pub struct LayoutRelation<'a> {
-    source_index: usize,
-    target_index: usize,
-    arrow_with_text: draw::ArrowWithText<'a>,
-}
-
-impl<'a> LayoutRelation<'a> {
-    /// Creates a new LayoutRelation from an AST relation and component indices.
-    ///
-    /// This method extracts the arrow definition and text from the AST relation
-    /// and creates a self-contained LayoutRelation that doesn't depend on the
-    /// original AST lifetime.
+    /// Calculates the intersection point where a line from this component's center
+    /// to an external point crosses this component's shape boundary.
     ///
     /// # Arguments
-    /// * `relation` - Reference to the AST relation being laid out
-    /// * `source_index` - Index of the source component in the layout
-    /// * `target_index` - Index of the target component in the layout
+    ///
+    /// * `external_point` - The point to draw a line toward from this component's center.
     ///
     /// # Returns
-    /// A new LayoutRelation containing all necessary rendering information
-    pub fn from_ast(
-        relation: &'a semantic::Relation,
-        source_index: usize,
-        target_index: usize,
-    ) -> Self {
-        let arrow_def = Rc::clone(relation.arrow_definition());
-        let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
-        let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
-        Self {
-            source_index,
-            target_index,
-            arrow_with_text,
-        }
+    ///
+    /// The point on this component's shape boundary where the line exits.
+    pub fn find_intersection(&self, external_point: Point) -> Point {
+        self.drawable
+            .inner()
+            .find_intersection(self.position(), external_point)
     }
+}
 
-    /// Returns a reference to the arrow with text for this relation.
-    pub fn arrow_with_text(&self) -> &draw::ArrowWithText<'_> {
-        &self.arrow_with_text
-    }
+/// Creates a [`PositionedArrowWithText`](draw::PositionedArrowWithText) from a semantic relation
+/// and positioned source/target components.
+///
+/// Computes the arrow path by finding the intersection points between the
+/// line connecting the source and target centers and each component's shape boundary.
+///
+/// # Arguments
+///
+/// * `relation` - The semantic relation to extract arrow definition and text from.
+/// * `source` - The source component (for boundary intersection calculation).
+/// * `target` - The target component (for boundary intersection calculation).
+///
+/// # Returns
+///
+/// A fully positioned arrow ready for rendering.
+pub fn positioned_arrow_from_relation<'a>(
+    relation: &'a semantic::Relation,
+    source: &Component,
+    target: &Component,
+) -> draw::PositionedArrowWithText<'a> {
+    let arrow_def = Rc::clone(relation.arrow_definition());
+    let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
+    let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
+
+    let source_edge = source.find_intersection(target.position());
+    let target_edge = target.find_intersection(source.position());
+    let path = draw::ArrowPath::straight(source_edge, target_edge);
+
+    draw::PositionedArrowWithText::new(arrow_with_text, path)
 }
 
 /// A complete layout of components and their relationships.
@@ -135,13 +138,16 @@ impl<'a> LayoutRelation<'a> {
 #[derive(Debug, Clone)]
 pub struct Layout<'a> {
     components: Vec<Component<'a>>,
-    relations: Vec<LayoutRelation<'a>>,
+    relations: Vec<draw::PositionedArrowWithText<'a>>,
     bounds: Bounds,
 }
 
 impl<'a> Layout<'a> {
     /// Creates a new layout with the given components and relations.
-    pub fn new(components: Vec<Component<'a>>, relations: Vec<LayoutRelation<'a>>) -> Self {
+    pub fn new(
+        components: Vec<Component<'a>>,
+        relations: Vec<draw::PositionedArrowWithText<'a>>,
+    ) -> Self {
         let bounds = if components.is_empty() {
             Bounds::default()
         } else {
@@ -166,24 +172,8 @@ impl<'a> Layout<'a> {
     }
 
     /// Returns a reference to the relations in this layout.
-    pub fn relations(&self) -> &[LayoutRelation<'a>] {
+    pub fn relations(&self) -> &[draw::PositionedArrowWithText<'a>] {
         &self.relations
-    }
-
-    /// Returns a reference to the source component of the given relation.
-    ///
-    /// # Panics
-    /// Panics if the source index is out of bounds.
-    pub fn source(&self, lr: &LayoutRelation) -> &Component<'_> {
-        &self.components[lr.source_index]
-    }
-
-    /// Returns a reference to the target component of the given relation.
-    ///
-    /// # Panics
-    /// Panics if the target index is out of bounds.
-    pub fn target(&self, lr: &LayoutRelation) -> &Component<'_> {
-        &self.components[lr.target_index]
     }
 }
 

--- a/crates/orrery/src/layout/engines/basic/component.rs
+++ b/crates/orrery/src/layout/engines/basic/component.rs
@@ -18,7 +18,7 @@ use orrery_core::{
 use crate::{
     error::RenderError,
     layout::{
-        component::{Component, Layout, LayoutRelation, adjust_positioned_contents_offset},
+        component::{self, Component, Layout, adjust_positioned_contents_offset},
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -134,7 +134,7 @@ impl Engine {
                 .collect();
 
             // Build the list of relations between components
-            let relations: Vec<LayoutRelation> = graph
+            let relations: Vec<draw::PositionedArrowWithText> = graph
                 .scope_relations(containment_scope)
                 .filter_map(|relation| {
                     // Only include relations between visible components
@@ -143,10 +143,10 @@ impl Engine {
                         component_indices.get(&relation.source()),
                         component_indices.get(&relation.target()),
                     ) {
-                        Some(LayoutRelation::from_ast(
+                        Some(component::positioned_arrow_from_relation(
                             relation,
-                            source_index,
-                            target_index,
+                            &components[source_index],
+                            &components[target_index],
                         ))
                     } else {
                         None

--- a/crates/orrery/src/layout/engines/basic/sequence.rs
+++ b/crates/orrery/src/layout/engines/basic/sequence.rs
@@ -18,10 +18,66 @@ use crate::{
         component::Component,
         engines::{EmbeddedLayouts, SequenceEngine},
         layer::{ContentStack, PositionedContent},
-        sequence::{ActivationBox, ActivationTiming, FragmentTiming, Layout, Message, Participant},
+        sequence::{self, ActivationBox, ActivationTiming, FragmentTiming, Layout, Participant},
     },
     structure::{SequenceEvent, SequenceGraph},
 };
+
+/// A message between two participants during event processing.
+///
+/// Holds the arrow definition and vertical position before the full path can be
+/// computed (activation boxes may not be finalized yet during event processing).
+struct Message<'a> {
+    source: Id,
+    target: Id,
+    y_position: f32,
+    arrow_with_text: draw::ArrowWithText<'a>,
+}
+
+impl<'a> Message<'a> {
+    /// Creates a message from a semantic relation and participant IDs.
+    fn from_relation(relation: &'a semantic::Relation, source: Id, target: Id) -> Self {
+        let arrow_def = Rc::clone(relation.arrow_definition());
+        let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
+        let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
+        Self {
+            source,
+            target,
+            y_position: 0.0,
+            arrow_with_text,
+        }
+    }
+
+    /// Returns the minimum size needed to render this message's arrow and text.
+    fn min_size(&self) -> Size {
+        self.arrow_with_text.min_size()
+    }
+
+    /// Sets the vertical center position for this message.
+    fn set_y_position(&mut self, y_position: f32) {
+        self.y_position = y_position;
+    }
+
+    /// Returns the source participant ID.
+    fn source(&self) -> Id {
+        self.source
+    }
+
+    /// Returns the target participant ID.
+    fn target(&self) -> Id {
+        self.target
+    }
+
+    /// Returns the vertical center position of this message.
+    fn y_position(&self) -> f32 {
+        self.y_position
+    }
+
+    /// Consumes self and returns the inner [`ArrowWithText`](draw::ArrowWithText).
+    fn into_arrow_with_text(self) -> draw::ArrowWithText<'a> {
+        self.arrow_with_text
+    }
+}
 
 /// Collected output from [`Engine::process_events`]: messages, activation boxes,
 /// fragments, notes, and the final Y coordinate.
@@ -222,6 +278,9 @@ impl Engine {
         let (messages, activations, fragments, notes, lifeline_end) =
             self.process_events(graph, participants_height, &components)?;
 
+        // Compute full arrow paths now that activation boxes are known.
+        let positioned_messages = Self::position_messages(messages, &activations, &components);
+
         // Update lifeline ends to match diagram height and finalize lifelines
         let participants: HashMap<Id, Participant<'a>> = components
             .into_iter()
@@ -242,7 +301,7 @@ impl Engine {
 
         let layout = Layout::new(
             participants,
-            messages,
+            positioned_messages,
             activations,
             fragments,
             notes,
@@ -253,6 +312,45 @@ impl Engine {
         content_stack.push(PositionedContent::new(layout));
 
         Ok(content_stack)
+    }
+
+    /// Computes arrow paths for messages using finalized activation boxes.
+    ///
+    /// Converts intermediate [`Message`] data into positioned arrows by calculating
+    /// the X endpoints based on active activation boxes at each message's Y position.
+    fn position_messages<'a>(
+        messages: Vec<Message<'a>>,
+        activations: &[ActivationBox],
+        components: &HashMap<Id, Component<'a>>,
+    ) -> Vec<draw::PositionedArrowWithText<'a>> {
+        messages
+            .into_iter()
+            .map(|msg| {
+                let source_participant = &components[&msg.source()];
+                let target_participant = &components[&msg.target()];
+
+                let source_x = sequence::calculate_message_endpoint_x(
+                    activations,
+                    source_participant,
+                    msg.source(),
+                    msg.y_position(),
+                    target_participant.position().x(),
+                );
+                let target_x = sequence::calculate_message_endpoint_x(
+                    activations,
+                    target_participant,
+                    msg.target(),
+                    msg.y_position(),
+                    source_participant.position().x(),
+                );
+
+                let start_point = Point::new(source_x, msg.y_position());
+                let end_point = Point::new(target_x, msg.y_position());
+                let path = draw::ArrowPath::straight(start_point, end_point);
+
+                draw::PositionedArrowWithText::new(msg.into_arrow_with_text(), path)
+            })
+            .collect()
     }
 
     /// Process all sequence diagram events to create layout components.
@@ -280,7 +378,7 @@ impl Engine {
     ///
     /// # Returns
     /// A tuple containing:
-    /// * `Vec<Message<'a>>` - All messages with their positions and arrow information
+    /// * `Vec<Message<'a>>` - Intermediate messages (to be finalized with computed paths).
     /// * `Vec<ActivationBox>` - All activation boxes with precise positioning and nesting levels
     /// * `Vec<draw::PositionedDrawable<draw::Fragment>>` - All fragments with their sections and bounds
     /// * `Vec<draw::PositionedDrawable<draw::Note>>` - All notes with their positions and content
@@ -308,7 +406,7 @@ impl Engine {
             match event {
                 SequenceEvent::Relation(relation) => {
                     let mut message =
-                        Message::from_ast(relation, relation.source(), relation.target());
+                        Message::from_relation(relation, relation.source(), relation.target());
                     let message_height = message.min_size().height();
 
                     // Center the arrow line within the message's vertical extent.

--- a/crates/orrery/src/layout/engines/graphviz/component.rs
+++ b/crates/orrery/src/layout/engines/graphviz/component.rs
@@ -39,7 +39,7 @@ use orrery_core::{
 use crate::{
     error::RenderError,
     layout::{
-        component::{Component, Layout, LayoutRelation, adjust_positioned_contents_offset},
+        component::{self, Component, Layout, adjust_positioned_contents_offset},
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -158,7 +158,7 @@ impl Engine {
                 .collect();
 
             // Build the list of relations between components
-            let relations: Vec<LayoutRelation> = graph
+            let relations: Vec<draw::PositionedArrowWithText> = graph
                 .scope_relations(containment_scope)
                 .filter_map(|relation| {
                     // Only include relations between visible components
@@ -167,10 +167,10 @@ impl Engine {
                         component_indices.get(&relation.source()),
                         component_indices.get(&relation.target()),
                     ) {
-                        Some(LayoutRelation::from_ast(
+                        Some(component::positioned_arrow_from_relation(
                             relation,
-                            source_index,
-                            target_index,
+                            &components[source_index],
+                            &components[target_index],
                         ))
                     } else {
                         None

--- a/crates/orrery/src/layout/engines/sugiyama/component.rs
+++ b/crates/orrery/src/layout/engines/sugiyama/component.rs
@@ -15,7 +15,7 @@ use orrery_core::{
 use crate::{
     error::RenderError,
     layout::{
-        component::{Component, Layout, LayoutRelation, adjust_positioned_contents_offset},
+        component::{self, Component, Layout, adjust_positioned_contents_offset},
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -123,7 +123,7 @@ impl Engine {
                 .collect();
 
             // Build the list of relations between components
-            let relations: Vec<LayoutRelation> = graph
+            let relations: Vec<draw::PositionedArrowWithText> = graph
                 .scope_relations(containment_scope)
                 .filter_map(|relation| {
                     // Only include relations between visible components
@@ -132,10 +132,10 @@ impl Engine {
                         component_indices.get(&relation.source()),
                         component_indices.get(&relation.target()),
                     ) {
-                        Some(LayoutRelation::from_ast(
+                        Some(component::positioned_arrow_from_relation(
                             relation,
-                            source_index,
-                            target_index,
+                            &components[source_index],
+                            &components[target_index],
                         ))
                     } else {
                         None

--- a/crates/orrery/src/layout/sequence.rs
+++ b/crates/orrery/src/layout/sequence.rs
@@ -46,68 +46,6 @@ impl<'a> Participant<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
-/// A rendered message between two participants at a specific Y position.
-pub struct Message<'a> {
-    source: Id,
-    target: Id,
-    y_position: f32,
-    arrow_with_text: draw::ArrowWithText<'a>,
-}
-
-impl<'a> Message<'a> {
-    /// Creates a new [`Message`] from a [`semantic::Relation`] and participant IDs.
-    ///
-    /// # Arguments
-    ///
-    /// * `relation` - The relation to extract arrow definition and text from.
-    /// * `source` - ID of the source participant.
-    /// * `target` - ID of the target participant.
-    pub fn from_ast(relation: &'a semantic::Relation, source: Id, target: Id) -> Self {
-        let arrow_def = Rc::clone(relation.arrow_definition());
-        let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
-        let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
-        Self {
-            source,
-            target,
-            y_position: 0.0,
-            arrow_with_text,
-        }
-    }
-
-    /// Returns the minimum [`Size`] needed to render this message.
-    ///
-    /// Delegates to [`ArrowWithText::min_size`](draw::ArrowWithText::min_size).
-    pub fn min_size(&self) -> Size {
-        self.arrow_with_text.min_size()
-    }
-
-    /// Sets the y-coordinate where this message appears.
-    pub fn set_y_position(&mut self, y_position: f32) {
-        self.y_position = y_position;
-    }
-
-    /// Returns a reference to the arrow with text for this message.
-    pub fn arrow_with_text(&self) -> &draw::ArrowWithText<'a> {
-        &self.arrow_with_text
-    }
-
-    /// Returns the ID of the source participant.
-    pub fn source(&self) -> Id {
-        self.source
-    }
-
-    /// Returns the ID of the target participant.
-    pub fn target(&self) -> Id {
-        self.target
-    }
-
-    /// Returns the y-coordinate where this message appears.
-    pub fn y_position(&self) -> f32 {
-        self.y_position
-    }
-}
-
 /// A rendered activation box in a sequence diagram.
 ///
 /// An [`ActivationBox`] is the final result of activation timing calculations, containing
@@ -479,7 +417,7 @@ pub fn calculate_message_endpoint_x(
 #[derive(Debug, Clone)]
 pub struct Layout<'a> {
     participants: HashMap<Id, Participant<'a>>,
-    messages: Vec<Message<'a>>,
+    messages: Vec<draw::PositionedArrowWithText<'a>>,
     activations: Vec<ActivationBox>,
     fragments: Vec<draw::PositionedDrawable<draw::Fragment>>,
     notes: Vec<draw::PositionedDrawable<draw::Note>>,
@@ -491,7 +429,7 @@ impl<'a> Layout<'a> {
     /// Construct a new sequence layout.
     pub fn new(
         participants: HashMap<Id, Participant<'a>>,
-        messages: Vec<Message<'a>>,
+        messages: Vec<draw::PositionedArrowWithText<'a>>,
         activations: Vec<ActivationBox>,
         fragments: Vec<draw::PositionedDrawable<draw::Fragment>>,
         notes: Vec<draw::PositionedDrawable<draw::Note>>,
@@ -521,7 +459,7 @@ impl<'a> Layout<'a> {
     }
 
     /// Borrow all messages in this sequence layout.
-    pub fn messages(&self) -> &[Message<'a>] {
+    pub fn messages(&self) -> &[draw::PositionedArrowWithText<'a>] {
         &self.messages
     }
 


### PR DESCRIPTION
Introduce ArrowPath and PositionedArrowWithText so layout engines compute
arrow positions (source, destination, control points) and pass them through
to rendering. The SVG renderer no longer computes intersection points — it consumes precomputed paths directly.

## Summary

Arrows now own their geometric path (source, destination, and control points) computed at layout time, rather than having the SVG renderer compute positions at render time. This enables layout engines to produce curved arrows and preserves computed edge paths through to rendering.

Key changes:
- `ArrowPath` struct in `arrow.rs` — holds source, destination, and control points
- `PositionedArrowWithText` in `arrow_with_text.rs` — pairs an `ArrowWithText` with its `ArrowPath`
- `Component::find_intersection` — moved from SVG layer to layout layer
- `positioned_arrow_from_relation` — constructs positioned arrows during layout
- All 3 component layout engines and the sequence layout engine compute straight paths at layout time
- SVG renderer simplified to a pure consumer of precomputed paths

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #109
