### PR TITLE
fix: remove redundant normalize_offset on embedded diagram containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING: Default `ArrowStyle` changed to `Curved`** — The default arrow style is now `Curved` (was `Straight`). `Curved` renders a straight line when no control points are provided, and follows bezier control points when they are. ([#106](https://github.com/orreryworks/orrery/issues/106))
 - **BREAKING: Arrow rendering API accepts control points** — `ArrowDrawer::draw_arrow`, `ArrowWithText::render_to_layers`, and `ArrowWithTextDrawer::draw_arrow_with_text` now require an additional `control_points: &[Point]` parameter. Pass `&[]` to preserve previous behavior. ([#106](https://github.com/orreryworks/orrery/issues/106))
 
+### Fixed
+
+- **Removed redundant `normalize_offset` on embedded diagram containers** — Container positions were double-shifted: once during component layout and again during layer composition. The redundant first shift displaced containers from their layout-assigned positions, causing overlap with siblings and cascading misalignment in multi-level nesting. ([#111](https://github.com/orreryworks/orrery/issues/111))
+
 ## [0.3.0] - 2026-05-03
 
 ### Added

--- a/crates/orrery/src/layout/engines.rs
+++ b/crates/orrery/src/layout/engines.rs
@@ -26,7 +26,6 @@ use crate::{
     layout::{
         component,
         layer::{LayeredLayout, LayoutContent},
-        positioning::LayoutBounds,
         sequence,
     },
     structure,
@@ -43,40 +42,11 @@ pub enum LayoutResult<'a> {
 }
 
 impl<'a> LayoutResult<'a> {
-    /// Calculate the coordinate offset needed to normalize this layout to start at origin.
-    ///
-    /// Embedded layouts may naturally have non-zero minimum points based on how their
-    /// positioning engines calculate positions. This method returns the offset that should
-    /// be applied to normalize the layout's coordinate system so its bounds start at origin (0, 0).
-    ///
-    /// Returns a Point that, when added to component positions, will shift the layout to
-    /// start at the origin.
-    pub fn normalize_offset(&self) -> geometry::Point {
-        let bounds = self.layout_bounds();
-        geometry::Point::new(-bounds.min_x(), -bounds.min_y())
-    }
-
     /// Calculate the size of this layout, using the appropriate sizing implementation
     fn calculate_size(&self) -> geometry::Size {
         match self {
             LayoutResult::Component(layout) => layout.layout_size(),
             LayoutResult::Sequence(layout) => layout.layout_size(),
-        }
-    }
-
-    /// Calculate the bounds of this layout
-    fn layout_bounds(&self) -> geometry::Bounds {
-        match self {
-            LayoutResult::Component(layout) => layout
-                .iter()
-                .last()
-                .map(|content| content.content().layout_bounds())
-                .unwrap_or_default(),
-            LayoutResult::Sequence(layout) => layout
-                .iter()
-                .last()
-                .map(|content| content.content().layout_bounds())
-                .unwrap_or_default(),
         }
     }
 }

--- a/crates/orrery/src/layout/engines/basic/component.rs
+++ b/crates/orrery/src/layout/engines/basic/component.rs
@@ -103,7 +103,7 @@ impl Engine {
             let components: Vec<Component> = graph
                 .scope_nodes(containment_scope)
                 .map(|node| {
-                    let mut position = *positions.get(&node.id()).ok_or_else(|| {
+                    let position = *positions.get(&node.id()).ok_or_else(|| {
                         RenderError::Layout(format!(
                             "Position not found for node '{node}' during component layout"
                         ))
@@ -113,14 +113,6 @@ impl Engine {
                             "Shape not found for node '{node}' during component layout"
                         ))
                     })?;
-
-                    // If this node contains an embedded diagram, adjust position to normalize
-                    // the embedded layout's coordinate system to start at origin
-                    if let semantic::Block::Diagram(_) = node.block()
-                        && let Some(layout) = embedded_layouts.get(&node.id())
-                    {
-                        position = position.add_point(layout.normalize_offset());
-                    }
 
                     Ok(Component::new(node, shape_with_text, position))
                 })

--- a/crates/orrery/src/layout/engines/basic/sequence.rs
+++ b/crates/orrery/src/layout/engines/basic/sequence.rs
@@ -254,15 +254,7 @@ impl Engine {
             let shape_with_text = participant_shapes.remove(&node.id()).ok_or_else(|| {
                 RenderError::Layout(format!("Participant shape not found for node '{node}'"))
             })?;
-            let mut position = Point::new(x_positions[i], self.top_margin);
-
-            // If this node contains an embedded diagram, adjust position to normalize
-            // the embedded layout's coordinate system to start at origin
-            if let semantic::Block::Diagram(_) = node.block()
-                && let Some(layout) = embedded_layouts.get(&node.id())
-            {
-                position = position.add_point(layout.normalize_offset());
-            }
+            let position = Point::new(x_positions[i], self.top_margin);
 
             let component = Component::new(node, shape_with_text, position);
             components.insert(node.id(), component);

--- a/crates/orrery/src/layout/engines/graphviz/component.rs
+++ b/crates/orrery/src/layout/engines/graphviz/component.rs
@@ -137,17 +137,7 @@ impl Engine {
                     RenderError::Layout(format!("shape not found for node `{node}`"))
                 })?;
 
-                // If this node contains an embedded diagram, adjust position to normalize
-                // the embedded layout's coordinate system to start at origin
-                let final_position = if let semantic::Block::Diagram(_) = node.block()
-                    && let Some(layout) = embedded_layouts.get(&node.id())
-                {
-                    position.add_point(layout.normalize_offset())
-                } else {
-                    position
-                };
-
-                components.push(Component::new(node, shape_with_text, final_position));
+                components.push(Component::new(node, shape_with_text, position));
             }
 
             // Map node IDs to their component indices


### PR DESCRIPTION
## Summary

Container positions were double-shifted: once during component layout and again during layer composition. Remove the first shift so containers stay at their layout-assigned positions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #111 
