### PR TITLE
feat: Curve parallel arrows in basic component diagrams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "cosmic-text",
  "dot-generator",
  "dot-structures",
+ "float-cmp",
  "graphviz-rust",
  "indexmap",
  "layout-rs",

--- a/crates/orrery/Cargo.toml
+++ b/crates/orrery/Cargo.toml
@@ -41,3 +41,4 @@ dot-structures = { version = "0.1.2", optional = true }
 dot-generator = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
+float-cmp = "0.10"

--- a/crates/orrery/src/layout/component.rs
+++ b/crates/orrery/src/layout/component.rs
@@ -1,18 +1,9 @@
-//! Positioned diagram elements and their relationships.
+//! Positioned diagram elements and arrow placement.
 //!
-//! This module provides the core layout types for representing diagram elements
-//! with computed positions and sizes. A [`Component`] wraps a semantic node with
-//! positioning information and is used across all diagram kinds.
-//!
-//! # Types
-//!
-//! - [`Component`] - A positioned diagram element with bounds
-//! - [`Layout`] - A complete layout of components and their connecting relations
-//!
-//! # Functions
-//!
-//! - [`positioned_arrow_from_relation`] - Constructs a positioned arrow from a semantic relation
-//! - [`adjust_positioned_contents_offset`] - Adjusts nested content offsets based on containment
+//! A [`Component`] wraps a semantic node with its computed position and shape.
+//! An [`ArrowPlacer`] decides how relations between the same component pair
+//! are turned into visually distinct arrow paths (straight overlap vs. offset
+//! cubic-Bézier lanes).
 
 use std::{collections::HashMap, rc::Rc};
 
@@ -128,6 +119,188 @@ pub fn positioned_arrow_from_relation<'a>(
     let path = draw::ArrowPath::straight(source_edge, target_edge);
 
     draw::PositionedArrowWithText::new(arrow_with_text, path)
+}
+
+/// Strategy for routing a bucket of relations between the same unordered
+/// component pair into positioned arrows.
+///
+/// # Implementing
+///
+/// - `source` is the component whose [`node_id`](Component::node_id) is the
+///   *canonical* end of the pair, and `target` is the other end. For
+///   self-loop buckets the same [`Component`] is passed for both.
+/// - Relations within the bucket may go either direction; inspect
+///   [`Relation::source`](semantic::Relation::source) to determine orientation.
+/// - Return exactly one arrow per input relation, in the same order.
+pub trait ArrowPlacer {
+    /// Places a bucket of relations between the same component pair.
+    fn place<'a>(
+        &self,
+        relations: &[&'a semantic::Relation],
+        source: &Component<'_>,
+        target: &Component<'_>,
+    ) -> Vec<draw::PositionedArrowWithText<'a>>;
+}
+
+/// [`ArrowPlacer`] that emits a straight centerline path for every relation.
+///
+/// Parallel/reverse relations overlap into a single line. Exists as the
+/// behaviour-preserving baseline; [`CurvedArrowPlacer`] is the default.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StraightArrowPlacer;
+
+impl ArrowPlacer for StraightArrowPlacer {
+    fn place<'a>(
+        &self,
+        relations: &[&'a semantic::Relation],
+        source: &Component<'_>,
+        target: &Component<'_>,
+    ) -> Vec<draw::PositionedArrowWithText<'a>> {
+        relations
+            .iter()
+            .map(|relation| {
+                let (rel_src, rel_tgt) = align_to_relation(relation, source, target);
+                positioned_arrow_from_relation(relation, rel_src, rel_tgt)
+            })
+            .collect()
+    }
+}
+
+/// [`ArrowPlacer`] that places parallel/reverse relations on offset lanes
+/// encoded as cubic Bézier curves.
+///
+/// Each relation at bucket position `k` of `N` gets lane offset
+/// `(k - (N-1)/2) * lane_spacing`. Reverse-direction relations have their
+/// offset sign-flipped so `a -> b` and `b -> a` curve to opposite sides.
+///
+/// Lane endpoints are found by aiming each shape's intersection ray at the
+/// offset center of the other shape; control points sit at 1/3 and 2/3 of
+/// the resulting lane line. For `N == 1` the offset is zero, producing a
+/// straight path identical to [`StraightArrowPlacer`]. Self-loop buckets
+/// currently fall back to straight lines.
+#[derive(Debug, Clone, Copy)]
+pub struct CurvedArrowPlacer {
+    lane_spacing: f32,
+}
+
+impl CurvedArrowPlacer {
+    const DEFAULT_LANE_SPACING: f32 = 22.0;
+
+    pub fn new() -> Self {
+        Self {
+            lane_spacing: Self::DEFAULT_LANE_SPACING,
+        }
+    }
+
+    /// Packages `lane_geometry` output into a [`PositionedArrowWithText`](draw::PositionedArrowWithText).
+    fn curved_arrow<'a>(
+        relation: &'a semantic::Relation,
+        source: &Component<'_>,
+        target: &Component<'_>,
+        lane_offset: f32,
+    ) -> draw::PositionedArrowWithText<'a> {
+        let Some((path, label_position)) = Self::lane_geometry(source, target, lane_offset) else {
+            // Degenerate (zero-length centerline): fall back to straight.
+            return positioned_arrow_from_relation(relation, source, target);
+        };
+
+        let arrow_def = Rc::clone(relation.arrow_definition());
+        let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
+        let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
+
+        draw::PositionedArrowWithText::new(arrow_with_text, path)
+            .with_text_position(Some(label_position))
+    }
+
+    /// Computes the cubic-Bézier path and label position for a lane offset.
+    ///
+    /// Returns `None` when component centers coincide (zero-length centerline).
+    fn lane_geometry(
+        source: &Component<'_>,
+        target: &Component<'_>,
+        lane_offset: f32,
+    ) -> Option<(draw::ArrowPath, Point)> {
+        let src_center = source.position();
+        let tgt_center = target.position();
+
+        let delta = tgt_center.sub_point(src_center);
+        let len = delta.hypot();
+        if len == 0.0 {
+            return None;
+        }
+        let perp = Point::new(
+            -delta.y() / len * lane_offset,
+            delta.x() / len * lane_offset,
+        );
+
+        let midpoint = src_center.midpoint(tgt_center).add_point(perp);
+        let src_edge = source.find_intersection(midpoint);
+        let tgt_edge = target.find_intersection(midpoint);
+
+        // Control points at 1/3 and 2/3 of src_edge→tgt_edge, offset perpendicular.
+        let (third, two_thirds) = line_segment_thirds(src_edge, tgt_edge);
+        let cp1 = third.add_point(perp);
+        let cp2 = two_thirds.add_point(perp);
+
+        let path = draw::ArrowPath::new(src_edge, tgt_edge, vec![cp1, cp2]);
+        let label_position = cubic_bezier_midpoint(src_edge, cp1, cp2, tgt_edge);
+        Some((path, label_position))
+    }
+
+    /// Lane offset for position `k` of `n`, sign-flipped for reverse relations.
+    fn lane_offset_at(
+        &self,
+        k: usize,
+        n: usize,
+        relation: &semantic::Relation,
+        source_id: Id,
+    ) -> f32 {
+        let offset = ((k as f32) - ((n - 1) as f32) / 2.0) * self.lane_spacing;
+        if relation.source() != source_id {
+            -offset
+        } else {
+            offset
+        }
+    }
+}
+
+impl Default for CurvedArrowPlacer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArrowPlacer for CurvedArrowPlacer {
+    fn place<'a>(
+        &self,
+        relations: &[&'a semantic::Relation],
+        source: &Component<'_>,
+        target: &Component<'_>,
+    ) -> Vec<draw::PositionedArrowWithText<'a>> {
+        // Self-loop bucket: fall back to straight lines until a dedicated
+        // self-loop router lands.
+        if source.node_id() == target.node_id() {
+            return StraightArrowPlacer.place(relations, source, target);
+        }
+
+        let n = relations.len();
+        relations
+            .iter()
+            .enumerate()
+            .map(|(k, relation)| {
+                let (rel_src, rel_tgt) = align_to_relation(relation, source, target);
+
+                let lane_offset = self.lane_offset_at(k, n, relation, source.node_id());
+
+                if lane_offset == 0.0 {
+                    // Median lane (or N == 1): straight line.
+                    return positioned_arrow_from_relation(relation, rel_src, rel_tgt);
+                }
+
+                Self::curved_arrow(relation, rel_src, rel_tgt, lane_offset)
+            })
+            .collect()
+    }
 }
 
 /// A complete layout of components and their relationships.
@@ -266,4 +439,213 @@ pub fn adjust_positioned_contents_offset<'a>(
         }
     }
     Ok(())
+}
+
+/// Returns `(source, target)` or `(target, source)` depending on which
+/// component matches `relation.source()`.
+fn align_to_relation<'a, 'b>(
+    relation: &semantic::Relation,
+    source: &'b Component<'a>,
+    target: &'b Component<'a>,
+) -> (&'b Component<'a>, &'b Component<'a>) {
+    if relation.source() == source.node_id() {
+        (source, target)
+    } else {
+        (target, source)
+    }
+}
+
+fn line_segment_thirds(start: Point, end: Point) -> (Point, Point) {
+    let dx = (end.x() - start.x()) / 3.0;
+    let dy = (end.y() - start.y()) / 3.0;
+    (
+        Point::new(start.x() + dx, start.y() + dy),
+        Point::new(start.x() + 2.0 * dx, start.y() + 2.0 * dy),
+    )
+}
+
+fn cubic_bezier_midpoint(start: Point, cp1: Point, cp2: Point, end: Point) -> Point {
+    Point::new(
+        0.125 * start.x() + 0.375 * cp1.x() + 0.375 * cp2.x() + 0.125 * end.x(),
+        0.125 * start.y() + 0.375 * cp1.y() + 0.375 * cp2.y() + 0.125 * end.y(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use float_cmp::{approx_eq, assert_approx_eq};
+
+    use super::*;
+
+    fn assert_point_approx_eq(actual: Point, expected: Point) {
+        assert!(
+            approx_eq!(f32, actual.x(), expected.x(), epsilon = 0.01)
+                && approx_eq!(f32, actual.y(), expected.y(), epsilon = 0.01),
+            "expected ({}, {}), got ({}, {})",
+            expected.x(),
+            expected.y(),
+            actual.x(),
+            actual.y(),
+        );
+    }
+
+    fn make_relation(source: Id, target: Id) -> semantic::Relation {
+        semantic::Relation::new(
+            source,
+            target,
+            draw::ArrowDirection::Forward,
+            None,
+            Rc::new(draw::ArrowDefinition::default()),
+        )
+    }
+
+    fn make_node(name: &str) -> semantic::Node {
+        let id = Id::new(name);
+        let shape_def =
+            Rc::new(Box::new(draw::RectangleDefinition::new()) as Box<dyn draw::ShapeDefinition>);
+        semantic::Node::new(id, None, semantic::Block::None, shape_def)
+    }
+
+    fn make_component<'a>(node: &'a semantic::Node, position: Point) -> Component<'a> {
+        let shape = draw::Shape::new(Rc::clone(node.shape_definition()));
+        let shape_with_text = draw::ShapeWithText::new(shape, None);
+        Component::new(node, shape_with_text, position)
+    }
+
+    #[test]
+    fn line_segment_thirds_returns_third_points() {
+        let (cp1, cp2) = line_segment_thirds(Point::new(0.0, 0.0), Point::new(30.0, 60.0));
+        assert_eq!(cp1, Point::new(10.0, 20.0));
+        assert_eq!(cp2, Point::new(20.0, 40.0));
+    }
+
+    #[test]
+    fn cubic_bezier_midpoint_at_half() {
+        // For a degenerate cubic (control points colinear with endpoints), the
+        // parametric midpoint coincides with the geometric midpoint.
+        let s = Point::new(0.0, 0.0);
+        let cp1 = Point::new(30.0, 0.0);
+        let cp2 = Point::new(60.0, 0.0);
+        let d = Point::new(90.0, 0.0);
+        let mid = cubic_bezier_midpoint(s, cp1, cp2, d);
+        assert_eq!(mid, Point::new(45.0, 0.0));
+    }
+
+    #[test]
+    fn lane_offset_at_assigns_symmetric_lanes() {
+        let a_id = Id::new("a");
+        let b_id = Id::new("b");
+        let r0 = make_relation(a_id, b_id);
+        let r1 = make_relation(a_id, b_id);
+        let router = CurvedArrowPlacer { lane_spacing: 10.0 };
+
+        let off0 = router.lane_offset_at(0, 2, &r0, a_id);
+        let off1 = router.lane_offset_at(1, 2, &r1, a_id);
+        assert_eq!(off0, -5.0);
+        assert_eq!(off1, 5.0);
+    }
+
+    #[test]
+    fn lane_offset_at_three_relations_has_zero_median() {
+        let a_id = Id::new("a");
+        let b_id = Id::new("b");
+        let r = make_relation(a_id, b_id);
+        let router = CurvedArrowPlacer { lane_spacing: 10.0 };
+        assert_eq!(router.lane_offset_at(1, 3, &r, a_id), 0.0);
+        assert_eq!(router.lane_offset_at(2, 3, &r, a_id), 10.0);
+    }
+
+    #[test]
+    fn lane_offset_at_single_relation_is_zero() {
+        let a_id = Id::new("a");
+        let b_id = Id::new("b");
+        let r = make_relation(a_id, b_id);
+        let router = CurvedArrowPlacer::new();
+        assert_eq!(router.lane_offset_at(0, 1, &r, a_id), 0.0);
+    }
+
+    #[test]
+    fn lane_geometry_emits_cubic_bezier_with_two_control_points() {
+        // Shape size is 12x12 (half = 6). Components at (0,0) and (1000,0).
+        // lane_offset = 18, perp = (0, 18), midpoint = (500, 18).
+        // src_edge: ray from (0,0) toward (500,18) exits at x=6 → (6, 0.216).
+        // tgt_edge: ray from (1000,0) toward (500,18) exits at x=994 → (994, 0.216).
+        // cp1 = 1/3 of edge segment + perp = (335.33, 18.216).
+        // cp2 = 2/3 of edge segment + perp = (664.67, 18.216).
+        // label = cubic midpoint ≈ (500, 13.716).
+        let a_node = make_node("a");
+        let b_node = make_node("b");
+        let a = make_component(&a_node, Point::new(0.0, 0.0));
+        let b = make_component(&b_node, Point::new(1000.0, 0.0));
+
+        let (path, label) =
+            CurvedArrowPlacer::lane_geometry(&a, &b, 18.0).expect("non-degenerate centerline");
+
+        assert_eq!(path.control_points().len(), 2);
+
+        assert_point_approx_eq(path.source(), Point::new(6.0, 0.216));
+        assert_point_approx_eq(path.destination(), Point::new(994.0, 0.216));
+        assert_point_approx_eq(path.control_points()[0], Point::new(335.33, 18.216));
+        assert_point_approx_eq(path.control_points()[1], Point::new(664.67, 18.216));
+        assert_point_approx_eq(label, Point::new(500.0, 13.716));
+    }
+
+    #[test]
+    fn lane_geometry_opposite_offsets_produce_mirrored_control_points() {
+        let a_node = make_node("a");
+        let b_node = make_node("b");
+        let a = make_component(&a_node, Point::new(0.0, 0.0));
+        let b = make_component(&b_node, Point::new(1000.0, 0.0));
+
+        let (path_pos, _) = CurvedArrowPlacer::lane_geometry(&a, &b, 18.0).unwrap();
+        let (path_neg, _) = CurvedArrowPlacer::lane_geometry(&a, &b, -18.0).unwrap();
+
+        let cp1_pos = path_pos.control_points()[0];
+        let cp1_neg = path_neg.control_points()[0];
+        assert_point_approx_eq(cp1_neg, Point::new(cp1_pos.x(), -cp1_pos.y()));
+    }
+
+    #[test]
+    fn lane_geometry_offset_scales_with_magnitude() {
+        let a_node = make_node("a");
+        let b_node = make_node("b");
+        let a = make_component(&a_node, Point::new(0.0, 0.0));
+        let b = make_component(&b_node, Point::new(1000.0, 0.0));
+
+        let (path_small, _) = CurvedArrowPlacer::lane_geometry(&a, &b, 10.0).unwrap();
+        let (path_large, _) = CurvedArrowPlacer::lane_geometry(&a, &b, 40.0).unwrap();
+
+        let cp1_small = path_small.control_points()[0];
+        let cp1_large = path_large.control_points()[0];
+        // 4x lane offset → 4x perpendicular offset on control points.
+        assert_approx_eq!(f32, cp1_large.y() / cp1_small.y(), 4.0);
+    }
+
+    #[test]
+    fn lane_geometry_returns_none_for_zero_length_centerline() {
+        let a_node = make_node("a");
+        let a = make_component(&a_node, Point::new(0.0, 0.0));
+        assert!(CurvedArrowPlacer::lane_geometry(&a, &a, 18.0).is_none());
+    }
+
+    #[test]
+    fn place_produces_one_arrow_per_relation() {
+        let a_node = make_node("a");
+        let b_node = make_node("b");
+        let a = make_component(&a_node, Point::new(0.0, 0.0));
+        let b = make_component(&b_node, Point::new(100.0, 0.0));
+        let r1 = make_relation(a.node_id(), b.node_id());
+        let r2 = make_relation(a.node_id(), b.node_id());
+        let r3 = make_relation(b.node_id(), a.node_id());
+
+        let router = CurvedArrowPlacer::new();
+        let out = router.place(&[&r1, &r2, &r3], &a, &b);
+        assert_eq!(out.len(), 3);
+
+        // Self-loop bucket also returns one arrow per relation.
+        let r4 = make_relation(a.node_id(), a.node_id());
+        let r5 = make_relation(a.node_id(), a.node_id());
+        let out_self = router.place(&[&r4, &r5], &a, &a);
+        assert_eq!(out_self.len(), 2);
+    }
 }

--- a/crates/orrery/src/layout/engines/basic/component.rs
+++ b/crates/orrery/src/layout/engines/basic/component.rs
@@ -18,7 +18,9 @@ use orrery_core::{
 use crate::{
     error::RenderError,
     layout::{
-        component::{self, Component, Layout, adjust_positioned_contents_offset},
+        component::{
+            ArrowPlacer, Component, CurvedArrowPlacer, Layout, adjust_positioned_contents_offset,
+        },
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -39,6 +41,7 @@ pub struct Engine {
     text_padding: f32,
     /// Minimum spacing between adjacent components.
     min_spacing: f32,
+    arrow_placer: CurvedArrowPlacer,
 }
 
 impl Engine {
@@ -125,26 +128,12 @@ impl Engine {
                 .map(|(idx, component)| (component.node_id(), idx))
                 .collect();
 
-            // Build the list of relations between components
-            let relations: Vec<draw::PositionedArrowWithText> = graph
-                .scope_relations(containment_scope)
-                .filter_map(|relation| {
-                    // Only include relations between visible components
-                    // (not including relations within inner blocks)
-                    if let (Some(&source_index), Some(&target_index)) = (
-                        component_indices.get(&relation.source()),
-                        component_indices.get(&relation.target()),
-                    ) {
-                        Some(component::positioned_arrow_from_relation(
-                            relation,
-                            &components[source_index],
-                            &components[target_index],
-                        ))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
+            let relations = self.place_scope_relations(
+                graph,
+                containment_scope,
+                &components,
+                &component_indices,
+            );
 
             let positioned_content = PositionedContent::new(Layout::new(components, relations));
 
@@ -159,6 +148,49 @@ impl Engine {
         adjust_positioned_contents_offset(&mut content_stack, graph)?;
 
         Ok(content_stack)
+    }
+
+    /// Builds positioned arrows for all visible relations in a containment scope.
+    ///
+    /// Parallel/reverse relations between the same component pair are placed
+    /// together so the [`ArrowPlacer`] can offset them. Relations whose
+    /// endpoints are not visible at this scope are skipped.
+    fn place_scope_relations<'a>(
+        &self,
+        graph: &'a ComponentGraph<'a, '_>,
+        containment_scope: &ContainmentScope,
+        components: &[Component<'a>],
+        component_indices: &HashMap<Id, usize>,
+    ) -> Vec<draw::PositionedArrowWithText<'a>> {
+        let mut buckets: HashMap<(Id, Id), Vec<&'a semantic::Relation>> = HashMap::new();
+
+        for relation in graph.scope_relations(containment_scope) {
+            let source_id = relation.source();
+            let target_id = relation.target();
+
+            if !component_indices.contains_key(&source_id)
+                || !component_indices.contains_key(&target_id)
+            {
+                continue;
+            }
+
+            // Canonicalize the pair key so (a,b) and (b,a) land in the same bucket.
+            let key = if buckets.contains_key(&(target_id, source_id)) {
+                (target_id, source_id)
+            } else {
+                (source_id, target_id)
+            };
+            buckets.entry(key).or_default().push(relation);
+        }
+
+        buckets
+            .into_iter()
+            .flat_map(|((src_id, tgt_id), bucket)| {
+                let src = &components[component_indices[&src_id]];
+                let tgt = &components[component_indices[&tgt_id]];
+                self.arrow_placer.place(&bucket, src, tgt)
+            })
+            .collect()
     }
 
     /// Calculate component shapes with proper content size and padding.


### PR DESCRIPTION
## Summary

When multiple arrows connect the same two components, they now render as visually distinct curved paths instead of overlapping into a single line. Relations are grouped by component pair and each arrow is placed on an offset cubic-Bézier lane. Reverse arrows (`a -> b` and `b -> a`) curve to opposite sides. A single arrow between two components remains a straight line.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #121 
