### PR TITLE
feat(sugiyama): Curve parallel arrows in Sugiyama component diagrams

### DIFF
--- a/crates/orrery/src/layout/engines/sugiyama/component.rs
+++ b/crates/orrery/src/layout/engines/sugiyama/component.rs
@@ -15,7 +15,9 @@ use orrery_core::{
 use crate::{
     error::RenderError,
     layout::{
-        component::{self, Component, Layout, adjust_positioned_contents_offset},
+        component::{
+            ArrowPlacer, Component, CurvedArrowPlacer, Layout, adjust_positioned_contents_offset,
+        },
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -30,25 +32,24 @@ use crate::{
 pub struct Engine {
     /// Padding around text elements.
     text_padding: f32,
-
     /// Horizontal spacing between components.
     horizontal_spacing: f32,
-
     /// Vertical spacing between layers.
     vertical_spacing: f32,
-
     /// Container padding for nested components.
     container_padding: Insets,
+    arrow_placer: CurvedArrowPlacer,
 }
 
 impl Engine {
-    /// Create a new Sugiyama component layout engine.
+    /// Creates a new Sugiyama component layout engine.
     pub fn new() -> Self {
         Self {
             text_padding: 20.0,
             horizontal_spacing: 50.0,
             vertical_spacing: 80.0,
             container_padding: Insets::uniform(20.0),
+            arrow_placer: CurvedArrowPlacer::new(),
         }
     }
 
@@ -122,26 +123,12 @@ impl Engine {
                 .map(|(idx, component)| (component.node_id(), idx))
                 .collect();
 
-            // Build the list of relations between components
-            let relations: Vec<draw::PositionedArrowWithText> = graph
-                .scope_relations(containment_scope)
-                .filter_map(|relation| {
-                    // Only include relations between visible components
-                    // (not including relations within inner blocks)
-                    if let (Some(&source_index), Some(&target_index)) = (
-                        component_indices.get(&relation.source()),
-                        component_indices.get(&relation.target()),
-                    ) {
-                        Some(component::positioned_arrow_from_relation(
-                            relation,
-                            &components[source_index],
-                            &components[target_index],
-                        ))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
+            let relations = self.place_scope_relations(
+                graph,
+                containment_scope,
+                &components,
+                &component_indices,
+            );
 
             let positioned_content = PositionedContent::new(Layout::new(components, relations));
 
@@ -156,6 +143,49 @@ impl Engine {
         adjust_positioned_contents_offset(&mut content_stack, graph)?;
 
         Ok(content_stack)
+    }
+
+    /// Builds positioned arrows for all visible relations in a containment scope.
+    ///
+    /// Parallel/reverse relations between the same component pair are placed
+    /// together so the [`ArrowPlacer`] can offset them. Relations whose
+    /// endpoints are not visible at this scope are skipped.
+    fn place_scope_relations<'a>(
+        &self,
+        graph: &'a ComponentGraph<'a, '_>,
+        containment_scope: &ContainmentScope,
+        components: &[Component<'a>],
+        component_indices: &HashMap<Id, usize>,
+    ) -> Vec<draw::PositionedArrowWithText<'a>> {
+        let mut buckets: HashMap<(Id, Id), Vec<&'a semantic::Relation>> = HashMap::new();
+
+        for relation in graph.scope_relations(containment_scope) {
+            let source_id = relation.source();
+            let target_id = relation.target();
+
+            if !component_indices.contains_key(&source_id)
+                || !component_indices.contains_key(&target_id)
+            {
+                continue;
+            }
+
+            // Canonicalize the pair key so (a,b) and (b,a) land in the same bucket.
+            let key = if buckets.contains_key(&(target_id, source_id)) {
+                (target_id, source_id)
+            } else {
+                (source_id, target_id)
+            };
+            buckets.entry(key).or_default().push(relation);
+        }
+
+        buckets
+            .into_iter()
+            .flat_map(|((src_id, tgt_id), bucket)| {
+                let src = &components[component_indices[&src_id]];
+                let tgt = &components[component_indices[&tgt_id]];
+                self.arrow_placer.place(&bucket, src, tgt)
+            })
+            .collect()
     }
 
     /// Calculate component shapes with proper sizing and padding


### PR DESCRIPTION
## Summary

When multiple arrows connect the same two components in a Sugiyama-layout diagram, they now render as visually distinct curved paths instead of overlapping into a single line. Relations are grouped by component pair and each arrow is placed on an offset cubic-Bézier lane. A single arrow between two components remains a straight line.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

Closes #123
