### PR TITLE
refactor: simplify qualified paths with direct imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Simplified qualified import paths across workspace** — Replaced verbose `module::Type` qualified paths with direct imports, reordered module declarations before use statements per style conventions. ([#129](https://github.com/orreryworks/orrery/pull/129))
+
 ## [0.4.0] - 2026-05-23
 
 ### Added

--- a/crates/orrery-cli/tests/e2e_smoke_test.rs
+++ b/crates/orrery-cli/tests/e2e_smoke_test.rs
@@ -8,7 +8,7 @@ use std::{fs, path::PathBuf};
 use bumpalo::Bump;
 use tempfile::tempdir;
 
-use orrery_cli::{Args, run};
+use orrery_cli::Args;
 
 /// Collects all `.orr` files from a directory.
 fn collect_orr_files(dir: PathBuf) -> Vec<PathBuf> {
@@ -71,7 +71,7 @@ fn e2e_smoke_test_valid_examples() {
         };
 
         let arena = Bump::new();
-        if let Err(e) = run(&args, &arena) {
+        if let Err(e) = orrery_cli::run(&args, &arena) {
             failed_examples.push((example_path.clone(), e.to_string()));
         }
     }
@@ -127,7 +127,7 @@ fn e2e_smoke_test_error_examples() {
         };
 
         let arena = Bump::new();
-        if run(&args, &arena).is_ok() {
+        if orrery_cli::run(&args, &arena).is_ok() {
             unexpectedly_succeeded.push(example_path.clone());
         }
     }

--- a/crates/orrery-core/src/draw/arrow.rs
+++ b/crates/orrery-core/src/draw/arrow.rs
@@ -3,7 +3,7 @@
 //! This module provides types for defining and rendering arrows in diagrams,
 //! including stroke styling, path shapes, direction markers, and SVG output.
 
-use std::{collections::HashMap, fmt, rc::Rc, str};
+use std::{collections::HashMap, fmt, rc::Rc, str::FromStr};
 
 use svg::{self, node::element as svg_element};
 
@@ -28,7 +28,7 @@ pub enum ArrowStyle {
     Orthogonal,
 }
 
-impl str::FromStr for ArrowStyle {
+impl FromStr for ArrowStyle {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -133,7 +133,7 @@ impl ArrowDirection {
     }
 }
 
-impl str::FromStr for ArrowDirection {
+impl FromStr for ArrowDirection {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/crates/orrery-core/src/draw/shape.rs
+++ b/crates/orrery-core/src/draw/shape.rs
@@ -3,17 +3,6 @@
 //! This module provides the [`ShapeDefinition`] trait and [`Shape`] wrapper
 //! for rendering diagram node shapes (rectangles, ovals, actors, etc.).
 
-use std::rc::Rc;
-
-use crate::{
-    color::Color,
-    draw::{
-        Drawable, LayeredOutput, RenderLayer, StrokeDefinition, TextDefinition,
-        text_positioning::TextPositioningStrategy,
-    },
-    geometry::{Insets, Point, Size},
-};
-
 mod actor;
 mod boundary;
 mod component;
@@ -31,6 +20,17 @@ pub use entity::EntityDefinition;
 pub use interface::InterfaceDefinition;
 pub use oval::OvalDefinition;
 pub use rectangle::RectangleDefinition;
+
+use std::rc::Rc;
+
+use crate::{
+    color::Color,
+    draw::{
+        Drawable, LayeredOutput, RenderLayer, StrokeDefinition, TextDefinition,
+        text_positioning::TextPositioningStrategy,
+    },
+    geometry::{Insets, Point, Size},
+};
 
 /// A trait for shape definitions that provide stateless calculations.
 pub trait ShapeDefinition: std::fmt::Debug {

--- a/crates/orrery-core/src/semantic/diagram.rs
+++ b/crates/orrery-core/src/semantic/diagram.rs
@@ -7,15 +7,11 @@
 //! - [`Block`] - Represents nested content (none, scope, or embedded diagram)
 //! - [`LayoutEngine`] - Enumeration of available layout algorithms
 
-use std::{
-    fmt::{self, Display},
-    rc::Rc,
-    str::FromStr,
-};
+use std::{fmt, rc::Rc, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{color::Color, draw, semantic::element::Element};
+use crate::{color::Color, draw::LifelineDefinition, semantic::element::Element};
 
 /// The kind of a diagram: component or sequence.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -26,7 +22,7 @@ pub enum DiagramKind {
     Sequence,
 }
 
-impl Display for DiagramKind {
+impl fmt::Display for DiagramKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DiagramKind::Component => write!(f, "component"),
@@ -110,7 +106,7 @@ impl From<LayoutEngine> for &'static str {
     }
 }
 
-impl Display for LayoutEngine {
+impl fmt::Display for LayoutEngine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s: &'static str = (*self).into();
         write!(f, "{s}")
@@ -137,7 +133,7 @@ pub struct Diagram {
     scope: Scope,
     layout_engine: LayoutEngine,
     background_color: Option<Color>,
-    lifeline_definition: Option<Rc<draw::LifelineDefinition>>,
+    lifeline_definition: Option<Rc<LifelineDefinition>>,
 }
 
 impl Diagram {
@@ -147,7 +143,7 @@ impl Diagram {
         scope: Scope,
         layout_engine: LayoutEngine,
         background_color: Option<Color>,
-        lifeline_definition: Option<Rc<draw::LifelineDefinition>>,
+        lifeline_definition: Option<Rc<LifelineDefinition>>,
     ) -> Self {
         Self {
             kind,
@@ -179,7 +175,7 @@ impl Diagram {
     }
 
     /// Get the lifeline definition if specified (for sequence diagrams).
-    pub fn lifeline_definition(&self) -> Option<&Rc<draw::LifelineDefinition>> {
+    pub fn lifeline_definition(&self) -> Option<&Rc<LifelineDefinition>> {
         self.lifeline_definition.as_ref()
     }
 }

--- a/crates/orrery-core/src/semantic/element.rs
+++ b/crates/orrery-core/src/semantic/element.rs
@@ -2,7 +2,14 @@
 
 use std::{fmt, rc::Rc, str::FromStr};
 
-use crate::{draw, identifier::Id, semantic::diagram::Block};
+use crate::{
+    draw::{
+        ActivationBoxDefinition, ArrowDefinition, ArrowDirection, FragmentDefinition,
+        NoteDefinition, ShapeDefinition, Text,
+    },
+    identifier::Id,
+    semantic::diagram::Block,
+};
 
 /// A diagram node (component/participant) with visual definition and nested content.
 #[derive(Debug, Clone)]
@@ -10,7 +17,7 @@ pub struct Node {
     id: Id,
     display_name: Option<String>,
     block: Block,
-    shape_definition: Rc<Box<dyn draw::ShapeDefinition>>,
+    shape_definition: Rc<Box<dyn ShapeDefinition>>,
 }
 
 impl Node {
@@ -19,7 +26,7 @@ impl Node {
         id: Id,
         display_name: Option<String>,
         block: Block,
-        shape_definition: Rc<Box<dyn draw::ShapeDefinition>>,
+        shape_definition: Rc<Box<dyn ShapeDefinition>>,
     ) -> Self {
         Self {
             id,
@@ -40,7 +47,7 @@ impl Node {
     }
 
     /// Borrow the node's shape definition.
-    pub fn shape_definition(&self) -> &Rc<Box<dyn draw::ShapeDefinition>> {
+    pub fn shape_definition(&self) -> &Rc<Box<dyn ShapeDefinition>> {
         &self.shape_definition
     }
 
@@ -67,9 +74,9 @@ impl fmt::Display for Node {
 pub struct Relation {
     source: Id,
     target: Id,
-    arrow_direction: draw::ArrowDirection,
+    arrow_direction: ArrowDirection,
     label: Option<String>,
-    arrow_definition: Rc<draw::ArrowDefinition>,
+    arrow_definition: Rc<ArrowDefinition>,
 }
 
 impl Relation {
@@ -78,9 +85,9 @@ impl Relation {
     pub fn new(
         source: Id,
         target: Id,
-        arrow_direction: draw::ArrowDirection,
+        arrow_direction: ArrowDirection,
         label: Option<String>,
-        arrow_definition: Rc<draw::ArrowDefinition>,
+        arrow_definition: Rc<ArrowDefinition>,
     ) -> Self {
         Self {
             source,
@@ -92,14 +99,14 @@ impl Relation {
     }
 
     /// Build a Text drawable for the relation's label using its text definition, if a label exists.
-    pub fn text(&self) -> Option<draw::Text<'_>> {
+    pub fn text(&self) -> Option<Text<'_>> {
         let label = self.label.as_ref()?;
         let text_def = self.arrow_definition.text();
-        Some(draw::Text::new(text_def, label))
+        Some(Text::new(text_def, label))
     }
 
     /// Get the underlying ArrowDefinition Rc for rendering this relation.
-    pub fn arrow_definition(&self) -> &Rc<draw::ArrowDefinition> {
+    pub fn arrow_definition(&self) -> &Rc<ArrowDefinition> {
         &self.arrow_definition
     }
 
@@ -120,7 +127,7 @@ impl Relation {
     }
 
     /// Get the arrow direction for this relation.
-    pub fn arrow_direction(&self) -> draw::ArrowDirection {
+    pub fn arrow_direction(&self) -> ArrowDirection {
         self.arrow_direction
     }
 }
@@ -195,7 +202,7 @@ pub struct Note {
     /// Text content of the note
     content: String,
     /// Styling definition for the note
-    definition: Rc<draw::NoteDefinition>,
+    definition: Rc<NoteDefinition>,
 }
 
 impl Note {
@@ -204,7 +211,7 @@ impl Note {
         on: Vec<Id>,
         align: NoteAlign,
         content: String,
-        definition: Rc<draw::NoteDefinition>,
+        definition: Rc<NoteDefinition>,
     ) -> Self {
         Self {
             on,
@@ -230,7 +237,7 @@ impl Note {
     }
 
     /// Borrow the note's styling definition.
-    pub fn definition(&self) -> &Rc<draw::NoteDefinition> {
+    pub fn definition(&self) -> &Rc<NoteDefinition> {
         &self.definition
     }
 }
@@ -241,12 +248,12 @@ pub struct Activate {
     /// Component ID being activated
     component: Id,
     /// Styling definition for the activation box
-    definition: Rc<draw::ActivationBoxDefinition>,
+    definition: Rc<ActivationBoxDefinition>,
 }
 
 impl Activate {
     /// Create a new Activate.
-    pub fn new(component: Id, definition: Rc<draw::ActivationBoxDefinition>) -> Self {
+    pub fn new(component: Id, definition: Rc<ActivationBoxDefinition>) -> Self {
         Self {
             component,
             definition,
@@ -259,7 +266,7 @@ impl Activate {
     }
 
     /// Borrow the activation box styling definition.
-    pub fn definition(&self) -> &Rc<draw::ActivationBoxDefinition> {
+    pub fn definition(&self) -> &Rc<ActivationBoxDefinition> {
         &self.definition
     }
 }
@@ -276,7 +283,7 @@ pub struct Fragment {
     /// The sections within this fragment
     sections: Vec<FragmentSection>,
     /// The fragment definition for this fragment's styling
-    definition: Rc<draw::FragmentDefinition>,
+    definition: Rc<FragmentDefinition>,
 }
 
 impl Fragment {
@@ -284,7 +291,7 @@ impl Fragment {
     pub fn new(
         operation: String,
         sections: Vec<FragmentSection>,
-        definition: Rc<draw::FragmentDefinition>,
+        definition: Rc<FragmentDefinition>,
     ) -> Self {
         Self {
             operation,
@@ -306,7 +313,7 @@ impl Fragment {
     /// Get the fragment definition for this fragment.
     ///
     /// Returns a reference to the `Rc<FragmentDefinition>` allowing shared ownership of the definition.
-    pub fn definition(&self) -> &Rc<draw::FragmentDefinition> {
+    pub fn definition(&self) -> &Rc<FragmentDefinition> {
         &self.definition
     }
 }

--- a/crates/orrery-parser/src/builtin_types.rs
+++ b/crates/orrery-parser/src/builtin_types.rs
@@ -15,7 +15,15 @@
 
 use std::rc::Rc;
 
-use orrery_core::{draw, identifier::Id};
+use orrery_core::{
+    draw::{
+        ActivationBoxDefinition, ActorDefinition, ArrowDefinition, BoundaryDefinition,
+        ComponentDefinition, ControlDefinition, EntityDefinition, FragmentDefinition,
+        InterfaceDefinition, NoteDefinition, OvalDefinition, RectangleDefinition, ShapeDefinition,
+        StrokeDefinition, TextDefinition,
+    },
+    identifier::Id,
+};
 
 use crate::elaborate_utils::TypeDefinition;
 
@@ -101,7 +109,7 @@ impl BuiltinTypeBuilder {
     pub fn add_shape(
         mut self,
         name: &str,
-        shape_definition: impl draw::ShapeDefinition + 'static,
+        shape_definition: impl ShapeDefinition + 'static,
     ) -> Self {
         self.types.push(TypeDefinition::new_shape(
             Id::new(name),
@@ -113,7 +121,7 @@ impl BuiltinTypeBuilder {
     /// Add an arrow type definition with default text styling
     ///
     /// Returns `self` for method chaining.
-    pub fn add_arrow(mut self, name: &str, arrow_definition: draw::ArrowDefinition) -> Self {
+    pub fn add_arrow(mut self, name: &str, arrow_definition: ArrowDefinition) -> Self {
         self.types.push(TypeDefinition::new_arrow(
             Id::new(name),
             Rc::new(arrow_definition),
@@ -124,11 +132,7 @@ impl BuiltinTypeBuilder {
     /// Add a fragment type definition with default text styling
     ///
     /// Returns `self` for method chaining.
-    pub fn add_fragment(
-        mut self,
-        name: &str,
-        fragment_definition: draw::FragmentDefinition,
-    ) -> Self {
+    pub fn add_fragment(mut self, name: &str, fragment_definition: FragmentDefinition) -> Self {
         self.types.push(TypeDefinition::new_fragment(
             Id::new(name),
             Rc::new(fragment_definition),
@@ -139,7 +143,7 @@ impl BuiltinTypeBuilder {
     /// Add a note type definition
     ///
     /// Returns `self` for method chaining.
-    pub fn add_note(mut self, name: &str, note_definition: draw::NoteDefinition) -> Self {
+    pub fn add_note(mut self, name: &str, note_definition: NoteDefinition) -> Self {
         self.types.push(TypeDefinition::new_note(
             Id::new(name),
             Rc::new(note_definition),
@@ -153,7 +157,7 @@ impl BuiltinTypeBuilder {
     pub fn add_activation_box(
         mut self,
         name: &str,
-        activation_box_definition: draw::ActivationBoxDefinition,
+        activation_box_definition: ActivationBoxDefinition,
     ) -> Self {
         self.types.push(TypeDefinition::new_activation_box(
             Id::new(name),
@@ -165,7 +169,7 @@ impl BuiltinTypeBuilder {
     /// Add a stroke type definition
     ///
     /// Returns `self` for method chaining.
-    pub fn add_stroke(mut self, name: &str, stroke_definition: draw::StrokeDefinition) -> Self {
+    pub fn add_stroke(mut self, name: &str, stroke_definition: StrokeDefinition) -> Self {
         self.types
             .push(TypeDefinition::new_stroke(Id::new(name), stroke_definition));
         self
@@ -174,7 +178,7 @@ impl BuiltinTypeBuilder {
     /// Add a text type definition
     ///
     /// Returns `self` for method chaining.
-    pub fn add_text(mut self, name: &str, text_definition: draw::TextDefinition) -> Self {
+    pub fn add_text(mut self, name: &str, text_definition: TextDefinition) -> Self {
         self.types
             .push(TypeDefinition::new_text(Id::new(name), text_definition));
         self
@@ -196,29 +200,29 @@ impl BuiltinTypeBuilder {
 pub fn defaults() -> Vec<TypeDefinition> {
     BuiltinTypeBuilder::new()
         // Attribute group types
-        .add_stroke(STROKE, draw::StrokeDefinition::default())
-        .add_text(TEXT, draw::TextDefinition::default())
+        .add_stroke(STROKE, StrokeDefinition::default())
+        .add_text(TEXT, TextDefinition::default())
         // Shape types
-        .add_shape(RECTANGLE, draw::RectangleDefinition::new())
-        .add_shape(OVAL, draw::OvalDefinition::new())
-        .add_shape(COMPONENT, draw::ComponentDefinition::new())
-        .add_shape(BOUNDARY, draw::BoundaryDefinition::new())
-        .add_shape(ACTOR, draw::ActorDefinition::new())
-        .add_shape(ENTITY, draw::EntityDefinition::new())
-        .add_shape(CONTROL, draw::ControlDefinition::new())
-        .add_shape(INTERFACE, draw::InterfaceDefinition::new())
+        .add_shape(RECTANGLE, RectangleDefinition::new())
+        .add_shape(OVAL, OvalDefinition::new())
+        .add_shape(COMPONENT, ComponentDefinition::new())
+        .add_shape(BOUNDARY, BoundaryDefinition::new())
+        .add_shape(ACTOR, ActorDefinition::new())
+        .add_shape(ENTITY, EntityDefinition::new())
+        .add_shape(CONTROL, ControlDefinition::new())
+        .add_shape(INTERFACE, InterfaceDefinition::new())
         // Relation type
-        .add_arrow(ARROW, draw::ArrowDefinition::default())
+        .add_arrow(ARROW, ArrowDefinition::default())
         // Fragment type definitions for common operations
-        .add_fragment(FRAGMENT_ALT, draw::FragmentDefinition::new())
-        .add_fragment(FRAGMENT_OPT, draw::FragmentDefinition::new())
-        .add_fragment(FRAGMENT_LOOP, draw::FragmentDefinition::new())
-        .add_fragment(FRAGMENT_PAR, draw::FragmentDefinition::new())
-        .add_fragment(FRAGMENT, draw::FragmentDefinition::new())
+        .add_fragment(FRAGMENT_ALT, FragmentDefinition::new())
+        .add_fragment(FRAGMENT_OPT, FragmentDefinition::new())
+        .add_fragment(FRAGMENT_LOOP, FragmentDefinition::new())
+        .add_fragment(FRAGMENT_PAR, FragmentDefinition::new())
+        .add_fragment(FRAGMENT, FragmentDefinition::new())
         // Annotation type
-        .add_note(NOTE, draw::NoteDefinition::new())
+        .add_note(NOTE, NoteDefinition::new())
         // Activation type
-        .add_activation_box(ACTIVATE, draw::ActivationBoxDefinition::new())
+        .add_activation_box(ACTIVATE, ActivationBoxDefinition::new())
         .build()
 }
 
@@ -236,9 +240,9 @@ mod tests {
     #[test]
     fn test_builder_chaining() {
         let types = BuiltinTypeBuilder::new()
-            .add_shape(RECTANGLE, draw::RectangleDefinition::new())
-            .add_arrow(ARROW, draw::ArrowDefinition::default())
-            .add_note(NOTE, draw::NoteDefinition::new())
+            .add_shape(RECTANGLE, RectangleDefinition::new())
+            .add_arrow(ARROW, ArrowDefinition::default())
+            .add_note(NOTE, NoteDefinition::new())
             .build();
 
         assert_eq!(types.len(), 3);

--- a/crates/orrery-parser/src/desugar.rs
+++ b/crates/orrery-parser/src/desugar.rs
@@ -23,6 +23,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
+
 use orrery_core::identifier::Id;
 
 use crate::{

--- a/crates/orrery-parser/src/elaborate.rs
+++ b/crates/orrery-parser/src/elaborate.rs
@@ -8,10 +8,19 @@ use std::{collections::HashMap, mem, rc::Rc, str::FromStr};
 
 use log::{debug, info, trace};
 
-use orrery_core::{color::Color, draw, identifier::Id, semantic};
+use orrery_core::{
+    color::Color,
+    draw::{ArrowDirection, ArrowStyle, LifelineDefinition, StrokeDefinition, TextDefinition},
+    identifier::Id,
+    semantic::{
+        Activate, Block, Diagram, DiagramKind, Element, Fragment, FragmentSection, LayoutEngine,
+        Node, Note, NoteAlign, Relation, Scope,
+    },
+};
 
 use crate::{
-    builtin_types, elaborate_utils,
+    builtin_types,
+    elaborate_utils::{self, StrokeAttributeExtractor, TextAttributeExtractor},
     error::{Diagnostic, ErrorCode, Result},
     parser_types,
     span::{Span, Spanned},
@@ -24,17 +33,14 @@ use crate::{
 #[derive(Debug, Clone, Default)]
 pub struct ElaborateConfig {
     /// Default layout engine for component diagrams
-    pub component_layout: semantic::LayoutEngine,
+    pub component_layout: LayoutEngine,
     /// Default layout engine for sequence diagrams
-    pub sequence_layout: semantic::LayoutEngine,
+    pub sequence_layout: LayoutEngine,
 }
 
 impl ElaborateConfig {
     /// Creates a new [`ElaborateConfig`] with the specified layout engines.
-    pub fn new(
-        component_layout: semantic::LayoutEngine,
-        sequence_layout: semantic::LayoutEngine,
-    ) -> Self {
+    pub fn new(component_layout: LayoutEngine, sequence_layout: LayoutEngine) -> Self {
         Self {
             component_layout,
             sequence_layout,
@@ -54,7 +60,7 @@ impl ElaborateConfig {
 /// 1. Registers built-in type definitions
 /// 2. Processes user-defined types from the AST
 /// 3. Resolves type references and validates structure
-/// 4. Constructs the semantic [`Diagram`](orrery_core::semantic::Diagram)
+/// 4. Constructs the semantic [`Diagram`](orrery_core::Diagram)
 pub struct Builder {
     cfg: ElaborateConfig,
     type_definitions: HashMap<Id, elaborate_utils::TypeDefinition>,
@@ -82,7 +88,7 @@ impl Builder {
     // ============================================================================
 
     /// Consumes the builder and elaborates a [`FileAst`](parser_types::FileAst)
-    /// into a semantic [`Diagram`](semantic::Diagram).
+    /// into a semantic [`Diagram`](Diagram).
     ///
     /// This is the public entry point for elaboration. It delegates to
     /// [`build_diagram_from_file_ast`](Self::build_diagram_from_file_ast).
@@ -100,14 +106,14 @@ impl Builder {
     /// Returns an error if elaboration fails. This includes all semantic
     /// errors in the `E3xx` range, such as undefined types, invalid
     /// attributes, nested diagrams, or structural validation failures.
-    pub fn build(mut self, ast: &parser_types::FileAst) -> Result<semantic::Diagram> {
+    pub fn build(mut self, ast: &parser_types::FileAst) -> Result<Diagram> {
         debug!("Building elaborated diagram");
         self.build_diagram_from_file_ast(ast)
     }
 
     /// Builds a semantic diagram from a parsed file AST.
     ///
-    /// Converts a [`FileAst`](parser_types::FileAst) into a [`Diagram`](semantic::Diagram)
+    /// Converts a [`FileAst`](parser_types::FileAst) into a [`Diagram`](Diagram)
     /// by registering type definitions, extracting the diagram kind, processing
     /// elements into a scope, and resolving diagram-level attributes.
     ///
@@ -119,10 +125,7 @@ impl Builder {
     /// # Errors
     ///
     /// Returns an `E3xx` error if elaboration fails.
-    fn build_diagram_from_file_ast(
-        &mut self,
-        file_ast: &parser_types::FileAst,
-    ) -> Result<semantic::Diagram> {
+    fn build_diagram_from_file_ast(&mut self, file_ast: &parser_types::FileAst) -> Result<Diagram> {
         let (kind_spanned, attributes) = match &file_ast.header {
             parser_types::FileHeader::Diagram { kind, attributes } => (kind, attributes),
             parser_types::FileHeader::Library { span } => {
@@ -150,18 +153,18 @@ impl Builder {
         let block = self.build_block_from_elements(&file_ast.elements, kind)?;
 
         let scope = match block {
-            semantic::Block::None => {
+            Block::None => {
                 debug!("Empty block, using default scope");
-                semantic::Scope::default()
+                Scope::default()
             }
-            semantic::Block::Scope(scope) => {
+            Block::Scope(scope) => {
                 debug!(
                     elements_len = scope.elements().len();
                     "Using scope from block",
                 );
                 scope
             }
-            semantic::Block::Diagram(_) => {
+            Block::Diagram(_) => {
                 return Err(Diagnostic::error("nested diagram not allowed")
                     .with_code(ErrorCode::E305)
                     .with_label(kind_spanned.span(), "nested diagram")
@@ -177,7 +180,7 @@ impl Builder {
         // Restore parent type definitions.
         self.type_definitions = saved_type_defs;
 
-        Ok(semantic::Diagram::new(
+        Ok(Diagram::new(
             kind,
             scope,
             layout_engine,
@@ -203,7 +206,7 @@ impl Builder {
     fn build_diagram_from_diagram_source(
         &mut self,
         source: &parser_types::DiagramSource,
-    ) -> Result<semantic::Diagram> {
+    ) -> Result<Diagram> {
         match source {
             parser_types::DiagramSource::Inline(rc) => {
                 let file_ast = rc.borrow();
@@ -373,7 +376,7 @@ impl Builder {
         Ok(())
     }
 
-    /// Converts a slice of parser elements into a semantic [`Block`](semantic::Block).
+    /// Converts a slice of parser elements into a semantic [`Block`](Block).
     ///
     /// Returns `Block::None` for an empty slice, or wraps the elaborated elements
     /// in a `Block::Scope`. This function only produces `None` or `Scope` variants;
@@ -387,19 +390,19 @@ impl Builder {
     fn build_block_from_elements(
         &mut self,
         parser_elements: &[parser_types::Element],
-        diagram_kind: semantic::DiagramKind,
-    ) -> Result<semantic::Block> {
+        diagram_kind: DiagramKind,
+    ) -> Result<Block> {
         if parser_elements.is_empty() {
-            Ok(semantic::Block::None)
+            Ok(Block::None)
         } else {
-            Ok(semantic::Block::Scope(self.build_scope_from_elements(
+            Ok(Block::Scope(self.build_scope_from_elements(
                 parser_elements,
                 diagram_kind,
             )?))
         }
     }
 
-    /// Elaborates a slice of parser elements into a semantic [`Scope`](semantic::Scope).
+    /// Elaborates a slice of parser elements into a semantic [`Scope`](Scope).
     ///
     /// Dispatches each [`Element`](parser_types::Element) variant to the appropriate
     /// `build_*_element` method. Sugar variants (`ActivateBlock`, `AltElseBlock`,
@@ -412,8 +415,8 @@ impl Builder {
     fn build_scope_from_elements(
         &mut self,
         parser_elements: &[parser_types::Element],
-        diagram_kind: semantic::DiagramKind,
-    ) -> Result<semantic::Scope> {
+        diagram_kind: DiagramKind,
+    ) -> Result<Scope> {
         let mut elements = Vec::new();
 
         for parser_elm in parser_elements {
@@ -469,13 +472,13 @@ impl Builder {
             };
             elements.push(element);
         }
-        Ok(semantic::Scope::new(elements))
+        Ok(Scope::new(elements))
     }
 
     /// Builds a component element from parser data.
     ///
     /// Resolves the component's type definition, validates that the shape supports
-    /// content (if any), and constructs the semantic [`Node`](semantic::Node).
+    /// content (if any), and constructs the semantic [`Node`](Node).
     ///
     /// Content is determined by matching on [`ComponentContent`](parser_types::ComponentContent):
     /// - `None` — the component has no nested content.
@@ -496,8 +499,8 @@ impl Builder {
         type_spec: &parser_types::TypeSpec,
         content: &parser_types::ComponentContent,
         parser_elm: &parser_types::Element,
-        diagram_kind: semantic::DiagramKind,
-    ) -> Result<semantic::Element> {
+        diagram_kind: DiagramKind,
+    ) -> Result<Element> {
         let type_def = self.build_type_definition(type_spec)?;
 
         let shape_def = type_def.shape_definition().map_err(|err| {
@@ -523,30 +526,30 @@ impl Builder {
         }
 
         let block = match content {
-            parser_types::ComponentContent::None => semantic::Block::None,
+            parser_types::ComponentContent::None => Block::None,
             parser_types::ComponentContent::Scope(elements) => {
                 self.build_block_from_elements(elements, diagram_kind)?
             }
             parser_types::ComponentContent::Diagram(source) => {
-                semantic::Block::Diagram(self.build_diagram_from_diagram_source(source)?)
+                Block::Diagram(self.build_diagram_from_diagram_source(source)?)
             }
         };
 
-        let node = semantic::Node::new(
+        let node = Node::new(
             *name.inner(),
             display_name.as_ref().map(|n| n.to_string()),
             block,
             Rc::clone(shape_def),
         );
 
-        Ok(semantic::Element::Node(node))
+        Ok(Element::Node(node))
     }
 
     /// Builds a relation element from parser data.
     ///
     /// Resolves the arrow type definition, parses the arrow direction string
     /// (`->`, `<-`, `<->`, `-`), and constructs a semantic
-    /// [`Relation`](semantic::Relation).
+    /// [`Relation`](Relation).
     ///
     /// # Errors
     ///
@@ -559,7 +562,7 @@ impl Builder {
         relation_type: &Spanned<&str>,
         type_spec: &parser_types::TypeSpec,
         label: &Option<Spanned<String>>,
-    ) -> Result<semantic::Element> {
+    ) -> Result<Element> {
         // Extract relation type definition from type_spec
         let relation_type_def = self.build_type_definition(type_spec)?;
 
@@ -569,14 +572,14 @@ impl Builder {
                 .with_label(type_spec.span(), "invalid arrow type")
         })?;
 
-        let arrow_direction = draw::ArrowDirection::from_str(relation_type).map_err(|_| {
+        let arrow_direction = ArrowDirection::from_str(relation_type).map_err(|_| {
             Diagnostic::error(format!("invalid arrow direction `{relation_type}`"))
                 .with_code(ErrorCode::E302)
                 .with_label(relation_type.span(), "invalid direction")
                 .with_help("arrow direction must be `->`, `<-`, `<->`, or `-`")
         })?;
 
-        Ok(semantic::Element::Relation(semantic::Relation::new(
+        Ok(Element::Relation(Relation::new(
             *source.inner(),
             *target.inner(),
             arrow_direction,
@@ -589,7 +592,7 @@ impl Builder {
     ///
     /// Validates that activation is only used in sequence diagrams, resolves the
     /// activation-box type definition, and constructs a semantic
-    /// [`Activate`](semantic::Activate).
+    /// [`Activate`](Activate).
     ///
     /// # Errors
     ///
@@ -599,10 +602,10 @@ impl Builder {
         &mut self,
         component: &Spanned<Id>,
         type_spec: &parser_types::TypeSpec,
-        diagram_kind: semantic::DiagramKind,
-    ) -> Result<semantic::Element> {
+        diagram_kind: DiagramKind,
+    ) -> Result<Element> {
         // Only allow activate in sequence diagrams
-        if diagram_kind != semantic::DiagramKind::Sequence {
+        if diagram_kind != DiagramKind::Sequence {
             return Err(Diagnostic::error(
                 "activate statements are only supported in sequence diagrams",
             )
@@ -621,7 +624,7 @@ impl Builder {
                     .with_label(type_spec.span(), "invalid activation box type")
             })?;
 
-        Ok(semantic::Element::Activate(semantic::Activate::new(
+        Ok(Element::Activate(Activate::new(
             *component.inner(),
             Rc::clone(activation_box_def),
         )))
@@ -630,7 +633,7 @@ impl Builder {
     /// Builds a deactivate element from parser data.
     ///
     /// Validates that deactivation is only used in sequence diagrams and
-    /// constructs a semantic [`Deactivate`](semantic::Element::Deactivate).
+    /// constructs a semantic [`Deactivate`](Element::Deactivate).
     ///
     /// # Errors
     ///
@@ -638,10 +641,10 @@ impl Builder {
     fn build_deactivate_element(
         &mut self,
         component: &Spanned<Id>,
-        diagram_kind: semantic::DiagramKind,
-    ) -> Result<semantic::Element> {
+        diagram_kind: DiagramKind,
+    ) -> Result<Element> {
         // Only allow deactivate in sequence diagrams
-        if diagram_kind != semantic::DiagramKind::Sequence {
+        if diagram_kind != DiagramKind::Sequence {
             return Err(Diagnostic::error(
                 "deactivate statements are only supported in sequence diagrams",
             )
@@ -652,14 +655,14 @@ impl Builder {
             ));
         }
 
-        Ok(semantic::Element::Deactivate(*component.inner()))
+        Ok(Element::Deactivate(*component.inner()))
     }
 
     /// Builds a fragment element from parser data.
     ///
     /// Validates that fragments are only used in sequence diagrams, resolves the
     /// fragment type definition, and elaborates each section's elements into
-    /// a [`FragmentSection`](semantic::FragmentSection).
+    /// a [`FragmentSection`](FragmentSection).
     ///
     /// # Errors
     ///
@@ -668,10 +671,10 @@ impl Builder {
     fn build_fragment_element(
         &mut self,
         fragment: &parser_types::Fragment,
-        diagram_kind: semantic::DiagramKind,
-    ) -> Result<semantic::Element> {
+        diagram_kind: DiagramKind,
+    ) -> Result<Element> {
         // Only allow fragments in sequence diagrams
-        if diagram_kind != semantic::DiagramKind::Sequence {
+        if diagram_kind != DiagramKind::Sequence {
             return Err(Diagnostic::error(
                 "fragment blocks are only supported in sequence diagrams",
             )
@@ -704,13 +707,13 @@ impl Builder {
             let scope = self.build_scope_from_elements(&parser_section.elements, diagram_kind)?;
             let elements_vec = scope.elements().to_vec();
 
-            sections.push(semantic::FragmentSection::new(
+            sections.push(FragmentSection::new(
                 parser_section.title.as_ref().map(|t| t.inner().to_string()),
                 elements_vec,
             ));
         }
 
-        Ok(semantic::Element::Fragment(semantic::Fragment::new(
+        Ok(Element::Fragment(Fragment::new(
             fragment.operation.inner().to_string(),
             sections,
             Rc::clone(fragment_def),
@@ -753,8 +756,8 @@ impl Builder {
     fn resolve_text_type_reference(
         &self,
         type_spec: &parser_types::TypeSpec,
-        current_text_rc: &Rc<draw::TextDefinition>,
-    ) -> Result<Rc<draw::TextDefinition>> {
+        current_text_rc: &Rc<TextDefinition>,
+    ) -> Result<Rc<TextDefinition>> {
         // Step 1: Determine which Rc to use (current or resolved)
         let mut text_rc = if let Some(type_name) = &type_spec.type_name {
             let base_type = self
@@ -786,10 +789,7 @@ impl Builder {
         // Step 2: If attributes exist, make mutable and apply them
         if !type_spec.attributes.is_empty() {
             let text_def_mut = Rc::make_mut(&mut text_rc);
-            elaborate_utils::TextAttributeExtractor::extract_text_attributes(
-                text_def_mut,
-                &type_spec.attributes,
-            )?;
+            TextAttributeExtractor::extract_text_attributes(text_def_mut, &type_spec.attributes)?;
         }
 
         Ok(text_rc)
@@ -803,8 +803,8 @@ impl Builder {
     fn resolve_stroke_type_reference(
         &self,
         type_spec: &parser_types::TypeSpec,
-        current_stroke_rc: &Rc<draw::StrokeDefinition>,
-    ) -> Result<Rc<draw::StrokeDefinition>> {
+        current_stroke_rc: &Rc<StrokeDefinition>,
+    ) -> Result<Rc<StrokeDefinition>> {
         // Step 1: Determine which Rc to use (current or resolved)
         let mut stroke_rc = if let Some(type_name) = &type_spec.type_name {
             let base_type = self
@@ -836,7 +836,7 @@ impl Builder {
         // Step 2: If attributes exist, make mutable and apply them
         if !type_spec.attributes.is_empty() {
             let stroke_def_mut = Rc::make_mut(&mut stroke_rc);
-            elaborate_utils::StrokeAttributeExtractor::extract_stroke_attributes(
+            StrokeAttributeExtractor::extract_stroke_attributes(
                 stroke_def_mut,
                 &type_spec.attributes,
             )?;
@@ -926,7 +926,7 @@ impl Builder {
                         }
                         "style" => {
                             let style_str = Self::extract_string(attr, "style")?;
-                            let val = draw::ArrowStyle::from_str(style_str).map_err(|_| {
+                            let val = ArrowStyle::from_str(style_str).map_err(|_| {
                                 Diagnostic::error("invalid arrow style")
                                     .with_code(ErrorCode::E302)
                                     .with_label(attr.span(), "invalid style")
@@ -1109,18 +1109,12 @@ impl Builder {
             }
             elaborate_utils::DrawDefinition::Stroke(stroke_def) => {
                 let mut new_stroke = (**stroke_def).clone();
-                elaborate_utils::StrokeAttributeExtractor::extract_stroke_attributes(
-                    &mut new_stroke,
-                    attributes,
-                )?;
+                StrokeAttributeExtractor::extract_stroke_attributes(&mut new_stroke, attributes)?;
                 Ok(elaborate_utils::TypeDefinition::new_stroke(id, new_stroke))
             }
             elaborate_utils::DrawDefinition::Text(text_def) => {
                 let mut new_text_def = (**text_def).clone();
-                elaborate_utils::TextAttributeExtractor::extract_text_attributes(
-                    &mut new_text_def,
-                    attributes,
-                )?;
+                TextAttributeExtractor::extract_text_attributes(&mut new_text_def, attributes)?;
                 Ok(elaborate_utils::TypeDefinition::new_text(id, new_text_def))
             }
         }
@@ -1140,17 +1134,13 @@ impl Builder {
     /// Extract diagram attributes (layout engine, background color, and lifeline definition).
     fn extract_diagram_attributes(
         &self,
-        kind: semantic::DiagramKind,
+        kind: DiagramKind,
         attrs: &Vec<parser_types::Attribute<'_>>,
-    ) -> Result<(
-        semantic::LayoutEngine,
-        Option<Color>,
-        Option<Rc<draw::LifelineDefinition>>,
-    )> {
+    ) -> Result<(LayoutEngine, Option<Color>, Option<Rc<LifelineDefinition>>)> {
         // Set the default layout engine based on the diagram kind and config
         let mut layout_engine = match kind {
-            semantic::DiagramKind::Component => self.cfg.component_layout,
-            semantic::DiagramKind::Sequence => self.cfg.sequence_layout,
+            DiagramKind::Component => self.cfg.component_layout,
+            DiagramKind::Sequence => self.cfg.sequence_layout,
         };
 
         let mut background_color = None;
@@ -1168,7 +1158,7 @@ impl Builder {
                 }
                 "lifeline" => {
                     // Only valid for sequence diagrams
-                    if kind != semantic::DiagramKind::Sequence {
+                    if kind != DiagramKind::Sequence {
                         return Err(Diagnostic::error(
                             "`lifeline` attribute is only valid for sequence diagrams",
                         )
@@ -1201,11 +1191,11 @@ impl Builder {
     fn extract_lifeline_definition(
         &self,
         lifeline_attr: &parser_types::Attribute<'_>,
-    ) -> Result<draw::LifelineDefinition> {
+    ) -> Result<LifelineDefinition> {
         let type_spec = Self::extract_type_spec(lifeline_attr, "lifeline")?;
 
         // Start with default lifeline stroke
-        let default_stroke_rc = Rc::new(draw::StrokeDefinition::dashed(Color::default(), 1.0));
+        let default_stroke_rc = Rc::new(StrokeDefinition::dashed(Color::default(), 1.0));
 
         // Look for stroke attribute
         let stroke_rc =
@@ -1225,15 +1215,13 @@ impl Builder {
                 default_stroke_rc
             };
 
-        Ok(draw::LifelineDefinition::new(stroke_rc))
+        Ok(LifelineDefinition::new(stroke_rc))
     }
 
     /// Determines the layout engine from an attribute.
-    fn determine_layout_engine(
-        engine_attr: &parser_types::Attribute<'_>,
-    ) -> Result<semantic::LayoutEngine> {
+    fn determine_layout_engine(engine_attr: &parser_types::Attribute<'_>) -> Result<LayoutEngine> {
         let engine_str = Self::extract_string(engine_attr, "layout_engine")?;
-        semantic::LayoutEngine::from_str(engine_str).map_err(|_| {
+        LayoutEngine::from_str(engine_str).map_err(|_| {
             Diagnostic::error(format!("invalid `layout_engine` value: `{engine_str}`"))
                 .with_code(ErrorCode::E302)
                 .with_label(engine_attr.value.span(), "unsupported layout engine")
@@ -1260,8 +1248,8 @@ impl Builder {
     fn build_note_element(
         &mut self,
         note: &parser_types::Note,
-        diagram_kind: semantic::DiagramKind,
-    ) -> Result<semantic::Element> {
+        diagram_kind: DiagramKind,
+    ) -> Result<Element> {
         let type_def = self.build_type_definition(&note.type_spec)?;
 
         // Extract 'on' and 'align' attributes
@@ -1277,9 +1265,7 @@ impl Builder {
         })?;
         let note_def = Rc::clone(note_def_ref);
 
-        Ok(semantic::Element::Note(semantic::Note::new(
-            on, align, content, note_def,
-        )))
+        Ok(Element::Note(Note::new(on, align, content, note_def)))
     }
 
     /// Extract 'on' and 'align' attributes from note attributes.
@@ -1301,10 +1287,10 @@ impl Builder {
     fn extract_note_attributes(
         &mut self,
         attributes: &[parser_types::Attribute],
-        diagram_kind: semantic::DiagramKind,
-    ) -> Result<(Vec<Id>, semantic::NoteAlign)> {
+        diagram_kind: DiagramKind,
+    ) -> Result<(Vec<Id>, NoteAlign)> {
         let mut on: Option<Vec<Id>> = None;
-        let mut align: Option<semantic::NoteAlign> = None;
+        let mut align: Option<NoteAlign> = None;
 
         for attr in attributes {
             match *attr.name.inner() {
@@ -1321,7 +1307,7 @@ impl Builder {
                 "align" => {
                     let align_str = Self::extract_string(attr, "align")?;
 
-                    let alignment = align_str.parse::<semantic::NoteAlign>().map_err(|_| {
+                    let alignment = align_str.parse::<NoteAlign>().map_err(|_| {
                         Diagnostic::error(format!("invalid alignment value: `{}`", align_str))
                             .with_code(ErrorCode::E302)
                             .with_label(attr.value.span(), "invalid alignment")
@@ -1337,8 +1323,8 @@ impl Builder {
         // Apply defaults if not specified
         let on = on.unwrap_or_default();
         let align = align.unwrap_or(match diagram_kind {
-            semantic::DiagramKind::Sequence => semantic::NoteAlign::Over,
-            semantic::DiagramKind::Component => semantic::NoteAlign::Bottom,
+            DiagramKind::Sequence => NoteAlign::Over,
+            DiagramKind::Component => NoteAlign::Bottom,
         });
 
         Ok((on, align))
@@ -1370,7 +1356,7 @@ mod tests {
 
         let diagram = parser_types::FileAst {
             header: parser_types::FileHeader::Diagram {
-                kind: Spanned::new(semantic::DiagramKind::Component, Span::new(0..9)),
+                kind: Spanned::new(DiagramKind::Component, Span::new(0..9)),
                 attributes: vec![],
             },
             import_decls: vec![],
@@ -1423,7 +1409,7 @@ mod tests {
 
         let diagram = parser_types::FileAst {
             header: parser_types::FileHeader::Diagram {
-                kind: Spanned::new(semantic::DiagramKind::Sequence, Span::new(0..8)),
+                kind: Spanned::new(DiagramKind::Sequence, Span::new(0..8)),
                 attributes: vec![],
             },
             import_decls: vec![],
@@ -1444,7 +1430,7 @@ mod tests {
         let diagram = result.unwrap();
         // After desugaring, relations remain unscoped; ensure names were not prefixed
         for element in diagram.scope().elements() {
-            if let semantic::Element::Relation(relation) = element {
+            if let Element::Relation(relation) = element {
                 // Relations should maintain original naming, not be scoped under "user"
                 let source_str = relation.source().to_string();
                 let target_str = relation.target().to_string();
@@ -1533,7 +1519,7 @@ mod tests {
 
         let diagram = parser_types::FileAst {
             header: parser_types::FileHeader::Diagram {
-                kind: Spanned::new(semantic::DiagramKind::Sequence, Span::new(0..8)),
+                kind: Spanned::new(DiagramKind::Sequence, Span::new(0..8)),
                 attributes: vec![],
             },
             import_decls: vec![],
@@ -1558,7 +1544,7 @@ mod tests {
         let activations: Vec<_> = elems
             .iter()
             .filter_map(|e| {
-                if let semantic::Element::Activate(activate) = e {
+                if let Element::Activate(activate) = e {
                     Some(activate.component().to_string())
                 } else {
                     None
@@ -1568,7 +1554,7 @@ mod tests {
         let deactivations: Vec<_> = elems
             .iter()
             .filter_map(|e| {
-                if let semantic::Element::Deactivate(id) = e {
+                if let Element::Deactivate(id) = e {
                     Some(id.to_string())
                 } else {
                     None
@@ -1578,7 +1564,7 @@ mod tests {
         let relations: Vec<_> = elems
             .iter()
             .filter_map(|e| {
-                if let semantic::Element::Relation(r) = e {
+                if let Element::Relation(r) = e {
                     Some((r.source().to_string(), r.target().to_string()))
                 } else {
                     None
@@ -1646,7 +1632,7 @@ mod tests {
 
         let diagram = parser_types::FileAst {
             header: parser_types::FileHeader::Diagram {
-                kind: Spanned::new(semantic::DiagramKind::Sequence, Span::new(0..8)),
+                kind: Spanned::new(DiagramKind::Sequence, Span::new(0..8)),
                 attributes: vec![],
             },
             import_decls: vec![],
@@ -1672,7 +1658,7 @@ mod tests {
         );
 
         // Verify the activate element
-        if let semantic::Element::Activate(activate) = &elements[1] {
+        if let Element::Activate(activate) = &elements[1] {
             assert_eq!(
                 activate.component().to_string(),
                 "user",
@@ -1683,7 +1669,7 @@ mod tests {
         }
 
         // Verify the deactivate element
-        if let semantic::Element::Deactivate(id) = &elements[2] {
+        if let Element::Deactivate(id) = &elements[2] {
             assert_eq!(
                 id.to_string(),
                 "user",
@@ -1720,7 +1706,7 @@ mod tests {
 
         let diagram = parser_types::FileAst {
             header: parser_types::FileHeader::Diagram {
-                kind: Spanned::new(semantic::DiagramKind::Component, Span::new(0..9)),
+                kind: Spanned::new(DiagramKind::Component, Span::new(0..9)),
                 attributes: vec![],
             },
             import_decls: vec![],
@@ -1866,7 +1852,7 @@ mod tests {
 
         let diagram = parser_types::FileAst {
             header: parser_types::FileHeader::Diagram {
-                kind: Spanned::new(semantic::DiagramKind::Sequence, Span::new(0..8)),
+                kind: Spanned::new(DiagramKind::Sequence, Span::new(0..8)),
                 attributes: vec![],
             },
             import_decls: vec![],
@@ -1891,15 +1877,15 @@ mod tests {
         let elems = diagram.scope().elements();
         let relations = elems
             .iter()
-            .filter(|e| matches!(e, semantic::Element::Relation(_)))
+            .filter(|e| matches!(e, Element::Relation(_)))
             .count();
         let activates = elems
             .iter()
-            .filter(|e| matches!(e, semantic::Element::Activate(_)))
+            .filter(|e| matches!(e, Element::Activate(_)))
             .count();
         let deactivates = elems
             .iter()
-            .filter(|e| matches!(e, semantic::Element::Deactivate(_)))
+            .filter(|e| matches!(e, Element::Deactivate(_)))
             .count();
 
         assert!(
@@ -1931,14 +1917,14 @@ mod tests {
             content: Spanned::new("Test note".to_string(), Span::new(0..9)),
         };
 
-        let diagram_kind = semantic::DiagramKind::Sequence;
+        let diagram_kind = DiagramKind::Sequence;
         let result = builder.build_note_element(&note, diagram_kind);
 
         assert!(result.is_ok());
         let element = result.unwrap();
-        if let semantic::Element::Note(note_elem) = element {
+        if let Element::Note(note_elem) = element {
             assert_eq!(note_elem.on().len(), 0); // Margin note
-            assert_eq!(note_elem.align(), semantic::NoteAlign::Over); // Sequence default
+            assert_eq!(note_elem.align(), NoteAlign::Over); // Sequence default
             assert_eq!(note_elem.content(), "Test note");
         } else {
             panic!("Expected Note element");
@@ -1957,14 +1943,14 @@ mod tests {
             content: Spanned::new("Test note".to_string(), Span::new(0..9)),
         };
 
-        let diagram_kind = semantic::DiagramKind::Component;
+        let diagram_kind = DiagramKind::Component;
         let result = builder.build_note_element(&note, diagram_kind);
 
         assert!(result.is_ok());
         let element = result.unwrap();
-        if let semantic::Element::Note(note_elem) = element {
+        if let Element::Note(note_elem) = element {
             assert_eq!(note_elem.on().len(), 0); // Margin note
-            assert_eq!(note_elem.align(), semantic::NoteAlign::Bottom); // Component default
+            assert_eq!(note_elem.align(), NoteAlign::Bottom); // Component default
             assert_eq!(note_elem.content(), "Test note");
         } else {
             panic!("Expected Note element");
@@ -2028,14 +2014,14 @@ mod tests {
             content: Spanned::new("Styled note".to_string(), Span::new(0..11)),
         };
 
-        let diagram_kind = semantic::DiagramKind::Sequence;
+        let diagram_kind = DiagramKind::Sequence;
         let result = builder.build_note_element(&note, diagram_kind);
 
         assert!(result.is_ok());
         let element = result.unwrap();
-        if let semantic::Element::Note(note_elem) = element {
+        if let Element::Note(note_elem) = element {
             assert_eq!(note_elem.content(), "Styled note");
-            assert_eq!(note_elem.align(), semantic::NoteAlign::Over); // Default for sequence
+            assert_eq!(note_elem.align(), NoteAlign::Over); // Default for sequence
             assert_eq!(note_elem.on().len(), 0); // Margin note
         } else {
             panic!("Expected Note element");
@@ -2284,7 +2270,7 @@ mod tests {
         // database: Database;
         let child_ast = parser_types::FileAst {
             header: parser_types::FileHeader::Diagram {
-                kind: Spanned::new(semantic::DiagramKind::Sequence, Span::new(0..8)),
+                kind: Spanned::new(DiagramKind::Sequence, Span::new(0..8)),
                 attributes: vec![],
             },
             import_decls: vec![],
@@ -2321,7 +2307,7 @@ mod tests {
         // gateway -> auth_overview: "Auth detail";
         let parent_ast = parser_types::FileAst {
             header: parser_types::FileHeader::Diagram {
-                kind: Spanned::new(semantic::DiagramKind::Component, Span::new(0..9)),
+                kind: Spanned::new(DiagramKind::Component, Span::new(0..9)),
                 attributes: vec![],
             },
             import_decls: vec![],
@@ -2384,7 +2370,7 @@ mod tests {
         );
 
         let diagram = result.unwrap();
-        assert_eq!(diagram.kind(), semantic::DiagramKind::Component);
+        assert_eq!(diagram.kind(), DiagramKind::Component);
 
         // Verify the scope has all three elements: gateway, auth_overview, and a relation
         let elements = diagram.scope().elements();
@@ -2395,9 +2381,9 @@ mod tests {
         );
 
         // Verify the embedded node contains a diagram block
-        if let semantic::Element::Node(node) = &elements[1] {
+        if let Element::Node(node) = &elements[1] {
             assert!(
-                matches!(node.block(), semantic::Block::Diagram(_)),
+                matches!(node.block(), Block::Diagram(_)),
                 "auth_overview should contain an embedded diagram"
             );
         } else {

--- a/crates/orrery-parser/src/elaborate_utils.rs
+++ b/crates/orrery-parser/src/elaborate_utils.rs
@@ -6,7 +6,15 @@
 
 use std::{rc::Rc, str::FromStr};
 
-use orrery_core::{color::Color, draw, geometry::Insets, identifier::Id};
+use orrery_core::{
+    color::Color,
+    draw::{
+        ActivationBoxDefinition, ArrowDefinition, FragmentDefinition, NoteDefinition,
+        ShapeDefinition, StrokeCap, StrokeDefinition, StrokeJoin, StrokeStyle, TextDefinition,
+    },
+    geometry::Insets,
+    identifier::Id,
+};
 
 use crate::{
     error::{Diagnostic, ErrorCode, Result as DiagnosticResult},
@@ -16,13 +24,13 @@ use crate::{
 /// Unified drawing definition for types: either a shape or an arrow.
 #[derive(Debug, Clone)]
 pub enum DrawDefinition {
-    Shape(Rc<Box<dyn draw::ShapeDefinition>>),
-    Arrow(Rc<draw::ArrowDefinition>),
-    Fragment(Rc<draw::FragmentDefinition>),
-    Note(Rc<draw::NoteDefinition>),
-    ActivationBox(Rc<draw::ActivationBoxDefinition>),
-    Stroke(Rc<draw::StrokeDefinition>),
-    Text(Rc<draw::TextDefinition>),
+    Shape(Rc<Box<dyn ShapeDefinition>>),
+    Arrow(Rc<ArrowDefinition>),
+    Fragment(Rc<FragmentDefinition>),
+    Note(Rc<NoteDefinition>),
+    ActivationBox(Rc<ActivationBoxDefinition>),
+    Stroke(Rc<StrokeDefinition>),
+    Text(Rc<TextDefinition>),
 }
 
 /// A concrete, elaborated type with text styling and drawing definition.
@@ -41,40 +49,40 @@ impl TypeDefinition {
     }
 
     /// Construct a concrete shape type definition from a shape definition.
-    pub fn new_shape(id: Id, shape_definition: Rc<Box<dyn draw::ShapeDefinition>>) -> Self {
+    pub fn new_shape(id: Id, shape_definition: Rc<Box<dyn ShapeDefinition>>) -> Self {
         Self::new(id, DrawDefinition::Shape(shape_definition))
     }
 
     /// Construct a concrete arrow type definition from an arrow definition.
-    pub fn new_arrow(id: Id, arrow_definition: Rc<draw::ArrowDefinition>) -> Self {
+    pub fn new_arrow(id: Id, arrow_definition: Rc<ArrowDefinition>) -> Self {
         Self::new(id, DrawDefinition::Arrow(arrow_definition))
     }
 
     /// Construct a concrete fragment type definition from a fragment definition.
-    pub fn new_fragment(id: Id, fragment_definition: Rc<draw::FragmentDefinition>) -> Self {
+    pub fn new_fragment(id: Id, fragment_definition: Rc<FragmentDefinition>) -> Self {
         Self::new(id, DrawDefinition::Fragment(fragment_definition))
     }
 
     /// Construct a concrete note type definition from a note definition.
-    pub fn new_note(id: Id, note_definition: Rc<draw::NoteDefinition>) -> Self {
+    pub fn new_note(id: Id, note_definition: Rc<NoteDefinition>) -> Self {
         Self::new(id, DrawDefinition::Note(note_definition))
     }
 
     /// Construct a concrete activation box type definition from a activation box definition.
     pub fn new_activation_box(
         id: Id,
-        activation_box_definition: Rc<draw::ActivationBoxDefinition>,
+        activation_box_definition: Rc<ActivationBoxDefinition>,
     ) -> Self {
         Self::new(id, DrawDefinition::ActivationBox(activation_box_definition))
     }
 
     /// Construct a concrete stroke type definition from a stroke definition.
-    pub fn new_stroke(id: Id, stroke_definition: draw::StrokeDefinition) -> Self {
+    pub fn new_stroke(id: Id, stroke_definition: StrokeDefinition) -> Self {
         Self::new(id, DrawDefinition::Stroke(Rc::new(stroke_definition)))
     }
 
     /// Construct a concrete text type definition from a text definition.
-    pub fn new_text(id: Id, text_definition: draw::TextDefinition) -> Self {
+    pub fn new_text(id: Id, text_definition: TextDefinition) -> Self {
         Self::new(id, DrawDefinition::Text(Rc::new(text_definition)))
     }
 
@@ -89,7 +97,7 @@ impl TypeDefinition {
     }
 
     /// Borrow the shape definition if this type is a shape; otherwise returns an error.
-    pub fn shape_definition(&self) -> Result<&Rc<Box<dyn draw::ShapeDefinition>>, String> {
+    pub fn shape_definition(&self) -> Result<&Rc<Box<dyn ShapeDefinition>>, String> {
         match &self.draw_definition {
             DrawDefinition::Shape(shape) => Ok(shape),
             _ => Err(format!("Type '{}' is not a shape type", self.id)),
@@ -97,7 +105,7 @@ impl TypeDefinition {
     }
 
     /// Borrow the arrow definition if this type is an arrow; otherwise returns an error.
-    pub fn arrow_definition(&self) -> Result<&Rc<draw::ArrowDefinition>, String> {
+    pub fn arrow_definition(&self) -> Result<&Rc<ArrowDefinition>, String> {
         match &self.draw_definition {
             DrawDefinition::Arrow(arrow) => Ok(arrow),
             _ => Err(format!("Type '{}' is not an arrow type", self.id)),
@@ -105,7 +113,7 @@ impl TypeDefinition {
     }
 
     /// Borrow the fragment definition if this type is a fragment; otherwise returns an error.
-    pub fn fragment_definition(&self) -> Result<&Rc<draw::FragmentDefinition>, String> {
+    pub fn fragment_definition(&self) -> Result<&Rc<FragmentDefinition>, String> {
         match &self.draw_definition {
             DrawDefinition::Fragment(fragment) => Ok(fragment),
             _ => Err(format!("Type '{}' is not a fragment type", self.id)),
@@ -113,7 +121,7 @@ impl TypeDefinition {
     }
 
     /// Borrow the note definition if this type is a note; otherwise returns an error.
-    pub fn note_definition(&self) -> Result<&Rc<draw::NoteDefinition>, String> {
+    pub fn note_definition(&self) -> Result<&Rc<NoteDefinition>, String> {
         match &self.draw_definition {
             DrawDefinition::Note(note) => Ok(note),
             _ => Err(format!("Type '{}' is not a note type", self.id)),
@@ -121,7 +129,7 @@ impl TypeDefinition {
     }
 
     /// Borrow the activation box definition if this type is an activation box; otherwise returns an error.
-    pub fn activation_box_definition(&self) -> Result<&Rc<draw::ActivationBoxDefinition>, String> {
+    pub fn activation_box_definition(&self) -> Result<&Rc<ActivationBoxDefinition>, String> {
         match &self.draw_definition {
             DrawDefinition::ActivationBox(activation_box) => Ok(activation_box),
             _ => Err(format!("Type '{}' is not an activation box type", self.id)),
@@ -129,7 +137,7 @@ impl TypeDefinition {
     }
 
     /// Get the stroke definition Rc if this type is a stroke; otherwise returns an error.
-    pub fn stroke_definition(&self) -> Result<&Rc<draw::StrokeDefinition>, String> {
+    pub fn stroke_definition(&self) -> Result<&Rc<StrokeDefinition>, String> {
         match &self.draw_definition {
             DrawDefinition::Stroke(stroke) => Ok(stroke),
             _ => Err(format!("Type '{}' is not a stroke type", self.id)),
@@ -137,7 +145,7 @@ impl TypeDefinition {
     }
 
     /// Get the text definition Rc if this type is a text; otherwise returns an error.
-    pub fn text_definition_from_draw(&self) -> Result<&Rc<draw::TextDefinition>, String> {
+    pub fn text_definition_from_draw(&self) -> Result<&Rc<TextDefinition>, String> {
         match &self.draw_definition {
             DrawDefinition::Text(text) => Ok(text),
             _ => Err(format!("Type '{}' is not a text type", self.id)),
@@ -154,7 +162,7 @@ impl TextAttributeExtractor {
     /// Returns `Ok(())` if all attributes were processed successfully,
     /// `Err(...)` if any attribute has an invalid value or is not a valid text attribute.
     pub fn extract_text_attributes(
-        text_def: &mut draw::TextDefinition,
+        text_def: &mut TextDefinition,
         attrs: &[parser_types::Attribute],
     ) -> DiagnosticResult<()> {
         for attr in attrs {
@@ -168,7 +176,7 @@ impl TextAttributeExtractor {
     /// Returns `Ok(())` if the attribute was processed successfully,
     /// `Err(...)` if the attribute has an invalid value or is not a valid text attribute.
     fn extract_single_attribute(
-        text_def: &mut draw::TextDefinition,
+        text_def: &mut TextDefinition,
         attr: &parser_types::Attribute,
     ) -> DiagnosticResult<()> {
         let name = attr.name.inner();
@@ -252,7 +260,7 @@ pub struct StrokeAttributeExtractor;
 impl StrokeAttributeExtractor {
     /// Extract and apply stroke-related attributes to a StrokeDefinition from a group of nested attributes.
     pub fn extract_stroke_attributes(
-        stroke_def: &mut draw::StrokeDefinition,
+        stroke_def: &mut StrokeDefinition,
         attrs: &[parser_types::Attribute],
     ) -> DiagnosticResult<()> {
         for attr in attrs {
@@ -263,7 +271,7 @@ impl StrokeAttributeExtractor {
 
     /// Extract and apply a single stroke-related attribute to a StrokeDefinition.
     fn extract_single_attribute(
-        stroke_def: &mut draw::StrokeDefinition,
+        stroke_def: &mut StrokeDefinition,
         attr: &parser_types::Attribute,
     ) -> DiagnosticResult<()> {
         let name = *attr.name.inner();
@@ -304,7 +312,7 @@ impl StrokeAttributeExtractor {
                         .with_help("stroke style must be a string")
                 })?;
 
-                let style = draw::StrokeStyle::from_str(style_str).map_err(|err| {
+                let style = StrokeStyle::from_str(style_str).map_err(|err| {
                     Diagnostic::error(err)
                         .with_code(ErrorCode::E302)
                         .with_label(attr.span(), "invalid stroke style")
@@ -321,7 +329,7 @@ impl StrokeAttributeExtractor {
                         .with_label(attr.span(), "invalid stroke cap value")
                         .with_help("stroke cap must be a string")
                 })?;
-                let cap = draw::StrokeCap::from_str(cap_str).map_err(|err| {
+                let cap = StrokeCap::from_str(cap_str).map_err(|err| {
                     Diagnostic::error(err)
                         .with_code(ErrorCode::E302)
                         .with_label(attr.span(), "invalid stroke cap")
@@ -337,7 +345,7 @@ impl StrokeAttributeExtractor {
                         .with_label(attr.span(), "invalid stroke join value")
                         .with_help("stroke join must be a string")
                 })?;
-                let join = draw::StrokeJoin::from_str(join_str).map_err(|err| {
+                let join = StrokeJoin::from_str(join_str).map_err(|err| {
                     Diagnostic::error(err)
                         .with_code(ErrorCode::E302)
                         .with_label(attr.span(), "invalid stroke join")
@@ -360,12 +368,14 @@ impl StrokeAttributeExtractor {
 
 #[cfg(test)]
 mod elaborate_tests {
+    use orrery_core::draw::RectangleDefinition;
+
     use super::*;
     use crate::span::{Span, Spanned};
 
     #[test]
     fn test_new_stroke_type() {
-        let stroke = draw::StrokeDefinition::default();
+        let stroke = StrokeDefinition::default();
         let type_def = TypeDefinition::new_stroke(Id::new("TestStroke"), stroke);
         assert_eq!(type_def.id(), "TestStroke");
         assert!(type_def.stroke_definition().is_ok());
@@ -374,7 +384,7 @@ mod elaborate_tests {
 
     #[test]
     fn test_new_text_type() {
-        let text = draw::TextDefinition::default();
+        let text = TextDefinition::default();
         let type_def = TypeDefinition::new_text(Id::new("TestText"), text);
         assert_eq!(type_def.id(), "TestText");
         assert!(type_def.text_definition_from_draw().is_ok());
@@ -385,7 +395,7 @@ mod elaborate_tests {
     fn test_shape_type_has_text_definition() {
         let type_def = TypeDefinition::new_shape(
             Id::new("Rect"),
-            Rc::new(Box::new(draw::RectangleDefinition::new())),
+            Rc::new(Box::new(RectangleDefinition::new())),
         );
         // Verify shape has embedded text
         assert!(type_def.shape_definition().is_ok());
@@ -414,7 +424,7 @@ mod elaborate_tests {
 
     #[test]
     fn test_text_attribute_extractor_all_attributes() {
-        let mut text_def = draw::TextDefinition::new();
+        let mut text_def = TextDefinition::new();
         let attributes = vec![
             create_test_attribute("font_size", create_float_value(16.0)),
             create_test_attribute("font_family", create_string_value("Helvetica")),
@@ -428,13 +438,13 @@ mod elaborate_tests {
 
     #[test]
     fn test_text_attribute_extractor_color_attribute() {
-        let mut text_def = draw::TextDefinition::new();
+        let mut text_def = TextDefinition::new();
         let attributes = vec![create_test_attribute("color", create_string_value("red"))];
         let result = TextAttributeExtractor::extract_text_attributes(&mut text_def, &attributes);
         assert!(result.is_ok());
 
         // Test with invalid color value (should be string)
-        let mut text_def = draw::TextDefinition::new();
+        let mut text_def = TextDefinition::new();
         let attributes = vec![create_test_attribute("color", create_float_value(255.0))];
         let result = TextAttributeExtractor::extract_text_attributes(&mut text_def, &attributes);
         assert!(result.is_err());
@@ -442,7 +452,7 @@ mod elaborate_tests {
 
     #[test]
     fn test_text_attribute_extractor_empty_attributes() {
-        let mut text_def = draw::TextDefinition::new();
+        let mut text_def = TextDefinition::new();
         let attributes = vec![];
 
         let result = TextAttributeExtractor::extract_text_attributes(&mut text_def, &attributes);
@@ -451,7 +461,7 @@ mod elaborate_tests {
 
     #[test]
     fn test_text_attribute_extractor_invalid_attribute_name() {
-        let mut text_def = draw::TextDefinition::new();
+        let mut text_def = TextDefinition::new();
         let attributes = vec![
             create_test_attribute("font_size", create_float_value(16.0)),
             create_test_attribute("invalid_attribute", create_string_value("test")),
@@ -469,7 +479,7 @@ mod elaborate_tests {
     #[test]
     fn test_text_attribute_extractor_invalid_value_types() {
         // Test font_size with string value (should be float)
-        let mut text_def = draw::TextDefinition::new();
+        let mut text_def = TextDefinition::new();
         let attributes = vec![create_test_attribute(
             "font_size",
             create_string_value("not_a_number"),
@@ -478,7 +488,7 @@ mod elaborate_tests {
         assert!(result.is_err());
 
         // Test font_family with float value (should be string)
-        let mut text_def = draw::TextDefinition::new();
+        let mut text_def = TextDefinition::new();
         let attributes = vec![create_test_attribute(
             "font_family",
             create_float_value(123.0),
@@ -497,22 +507,22 @@ mod elaborate_tests {
             create_test_attribute("join", create_string_value("bevel")),
         ];
 
-        let mut stroke_def = draw::StrokeDefinition::default();
+        let mut stroke_def = StrokeDefinition::default();
         let result = StrokeAttributeExtractor::extract_stroke_attributes(&mut stroke_def, &attrs);
 
         assert!(result.is_ok());
         assert_eq!(stroke_def.color().to_string(), "blue");
         assert_eq!(stroke_def.width(), 2.5);
-        assert_eq!(*stroke_def.style(), draw::StrokeStyle::Dashed);
-        assert_eq!(stroke_def.cap(), draw::StrokeCap::Round);
-        assert_eq!(stroke_def.join(), draw::StrokeJoin::Bevel);
+        assert_eq!(*stroke_def.style(), StrokeStyle::Dashed);
+        assert_eq!(stroke_def.cap(), StrokeCap::Round);
+        assert_eq!(stroke_def.join(), StrokeJoin::Bevel);
     }
 
     #[test]
     fn test_stroke_attribute_extractor_color_only() {
         let attrs = vec![create_test_attribute("color", create_string_value("red"))];
 
-        let mut stroke_def = draw::StrokeDefinition::default();
+        let mut stroke_def = StrokeDefinition::default();
         let result = StrokeAttributeExtractor::extract_stroke_attributes(&mut stroke_def, &attrs);
 
         assert!(result.is_ok());
@@ -526,7 +536,7 @@ mod elaborate_tests {
             create_string_value("value"),
         )];
 
-        let mut stroke_def = draw::StrokeDefinition::default();
+        let mut stroke_def = StrokeDefinition::default();
         let result = StrokeAttributeExtractor::extract_stroke_attributes(&mut stroke_def, &attrs);
 
         assert!(result.is_err());
@@ -544,7 +554,7 @@ mod elaborate_tests {
             create_string_value("not-a-valid-color-12345"),
         )];
 
-        let mut stroke_def = draw::StrokeDefinition::default();
+        let mut stroke_def = StrokeDefinition::default();
         let result = StrokeAttributeExtractor::extract_stroke_attributes(&mut stroke_def, &attrs);
 
         assert!(result.is_err());
@@ -558,7 +568,7 @@ mod elaborate_tests {
     fn test_stroke_attribute_extractor_invalid_cap() {
         let attrs = vec![create_test_attribute("cap", create_string_value("invalid"))];
 
-        let mut stroke_def = draw::StrokeDefinition::default();
+        let mut stroke_def = StrokeDefinition::default();
         let result = StrokeAttributeExtractor::extract_stroke_attributes(&mut stroke_def, &attrs);
 
         assert!(result.is_err());
@@ -575,7 +585,7 @@ mod elaborate_tests {
             create_string_value("invalid"),
         )];
 
-        let mut stroke_def = draw::StrokeDefinition::default();
+        let mut stroke_def = StrokeDefinition::default();
         let result = StrokeAttributeExtractor::extract_stroke_attributes(&mut stroke_def, &attrs);
 
         assert!(result.is_err());
@@ -588,11 +598,11 @@ mod elaborate_tests {
     #[test]
     fn test_stroke_attribute_extractor_all_predefined_styles() {
         let styles = vec![
-            ("solid", draw::StrokeStyle::Solid),
-            ("dashed", draw::StrokeStyle::Dashed),
-            ("dotted", draw::StrokeStyle::Dotted),
-            ("dash-dot", draw::StrokeStyle::DashDot),
-            ("dash-dot-dot", draw::StrokeStyle::DashDotDot),
+            ("solid", StrokeStyle::Solid),
+            ("dashed", StrokeStyle::Dashed),
+            ("dotted", StrokeStyle::Dotted),
+            ("dash-dot", StrokeStyle::DashDot),
+            ("dash-dot-dot", StrokeStyle::DashDotDot),
         ];
 
         for (style_str, expected_style) in styles {
@@ -600,7 +610,7 @@ mod elaborate_tests {
                 "style",
                 create_string_value(style_str),
             )];
-            let mut stroke_def = draw::StrokeDefinition::default();
+            let mut stroke_def = StrokeDefinition::default();
             let result =
                 StrokeAttributeExtractor::extract_stroke_attributes(&mut stroke_def, &attrs);
 

--- a/crates/orrery-parser/src/error.rs
+++ b/crates/orrery-parser/src/error.rs
@@ -36,12 +36,12 @@ mod parse_error;
 mod severity;
 mod source_error;
 
-pub(crate) use collector::DiagnosticCollector;
-pub(crate) use parse_error::Result;
-
 pub use diagnostic::Diagnostic;
 pub use error_code::ErrorCode;
 pub use label::Label;
 pub use parse_error::ParseError;
 pub use severity::Severity;
 pub use source_error::SourceError;
+
+pub(crate) use collector::DiagnosticCollector;
+pub(crate) use parse_error::Result;

--- a/crates/orrery-parser/src/parser.rs
+++ b/crates/orrery-parser/src/parser.rs
@@ -18,7 +18,10 @@ use orrery_core::{identifier::Id, semantic::DiagramKind};
 
 use crate::{
     error::{Diagnostic, ErrorCode},
-    parser_types as types,
+    parser_types::{
+        Attribute, AttributeValue, ComponentContent, DiagramSource, Element, FileAst, FileHeader,
+        Fragment, FragmentSection, ImportDecl, ImportForm, Note, TypeDefinition, TypeSpec,
+    },
     span::{Span, Spanned},
     tokens::{PositionedToken, Token},
 };
@@ -280,26 +283,21 @@ fn empty_brackets<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<()> {
 /// 3. **TypeSpec** - `TypeName[attr=val]`, `TypeName`, or `[attr=val]`
 /// 4. **String** - `"value"` - Text values (colors, names, alignment)
 /// 5. **Float** - `2.5` or `10` - Numeric values (widths, sizes, dimensions)
-fn attribute_value<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<types::AttributeValue<'src>> {
+fn attribute_value<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<AttributeValue<'src>> {
     alt((
         // Parse empty brackets [] first - can be interpreted as either empty identifiers or empty attributes
-        empty_brackets.map(|_| types::AttributeValue::Empty),
+        empty_brackets.map(|_| AttributeValue::Empty),
         // Try identifiers: [id1, id2, ...]
         // This needs to be before attribute_type_spec since both start with '['
-        identifiers.map(types::AttributeValue::Identifiers),
+        identifiers.map(AttributeValue::Identifiers),
         // Parse type spec: TypeName[attrs], TypeName, or [attrs]
-        attribute_type_spec.map(types::AttributeValue::TypeSpec),
+        attribute_type_spec.map(AttributeValue::TypeSpec),
         // Parse string or float literals
         any.verify_map(|token: &PositionedToken<'_>| match &token.token {
-            Token::StringLiteral(s) => Some(types::AttributeValue::String(Spanned::new(
-                s.clone(),
-                token.span,
-            ))),
-            Token::FloatLiteral(f) => {
-                Some(types::AttributeValue::Float(Spanned::new(*f, token.span)))
+            Token::StringLiteral(s) => {
+                Some(AttributeValue::String(Spanned::new(s.clone(), token.span)))
             }
+            Token::FloatLiteral(f) => Some(AttributeValue::Float(Spanned::new(*f, token.span))),
             _ => None,
         }),
     ))
@@ -308,7 +306,7 @@ fn attribute_value<'tok, 'src>(
 }
 
 /// Parse a single attribute
-fn attribute<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Attribute<'src>> {
+fn attribute<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Attribute<'src>> {
     let name = raw_identifier.parse_next(input)?;
 
     preceded(
@@ -321,11 +319,11 @@ fn attribute<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Attrib
 
     let value = attribute_value.parse_next(input)?;
 
-    Ok(types::Attribute { name, value })
+    Ok(Attribute { name, value })
 }
 
 /// Parse comma-separated attributes
-fn attributes<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Vec<types::Attribute<'src>>> {
+fn attributes<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Vec<Attribute<'src>>> {
     separated(
         0..,
         attribute,
@@ -340,9 +338,7 @@ fn attributes<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Vec<types::A
 }
 
 /// Parse attributes wrapped in brackets
-fn wrapped_attributes<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<Vec<types::Attribute<'src>>> {
+fn wrapped_attributes<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Vec<Attribute<'src>>> {
     delimited(
         (
             any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::LeftBracket)),
@@ -370,16 +366,14 @@ fn wrapped_attributes<'tok, 'src>(
 /// - `TypeName[attrs]` → TypeSpec { type_name: Some(TypeName), attributes: [...] }
 /// - `TypeName` → TypeSpec { type_name: Some(TypeName), attributes: [] }
 /// - `[attrs]` → TypeSpec { type_name: None, attributes: [...] }
-fn attribute_type_spec<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<types::TypeSpec<'src>> {
+fn attribute_type_spec<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<TypeSpec<'src>> {
     alt((
         // Try TypeName[attrs] or TypeName (reuse type_spec)
         type_spec,
         // Try [attrs] only (anonymous TypeSpec)
         |input: &mut Input<'tok, 'src>| {
             let attributes = wrapped_attributes.parse_next(input)?;
-            Ok(types::TypeSpec {
+            Ok(TypeSpec {
                 type_name: None,
                 attributes,
             })
@@ -394,7 +388,7 @@ fn attribute_type_spec<'tok, 'src>(
 /// Returns a TypeSpec with:
 /// - type_name: Always Some(id) - identifier is required
 /// - attributes: parsed attributes if present, empty vec otherwise
-fn type_spec<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::TypeSpec<'src>> {
+fn type_spec<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<TypeSpec<'src>> {
     let type_name = nested_identifier.parse_next(input)?;
 
     ws_comments0.parse_next(input)?;
@@ -403,7 +397,7 @@ fn type_spec<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::TypeSp
         .map(|attrs| attrs.unwrap_or_default())
         .parse_next(input)?;
 
-    Ok(types::TypeSpec {
+    Ok(TypeSpec {
         type_name: Some(type_name),
         attributes,
     })
@@ -419,9 +413,7 @@ fn type_spec<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::TypeSp
 /// - `@TypeName` → TypeSpec { type_name: Some(TypeName), attributes: [] }
 /// - `[attrs]` → TypeSpec { type_name: None, attributes: [...] }
 /// - (nothing) → TypeSpec::default() (sugar syntax)
-fn invocation_type_spec<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<types::TypeSpec<'src>> {
+fn invocation_type_spec<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<TypeSpec<'src>> {
     // Parse optional @TypeName
     // If @ is present, identifier is REQUIRED (cut_err prevents backtracking)
     // If @ is absent, we can still parse [attributes] or nothing (sugar)
@@ -446,7 +438,7 @@ fn invocation_type_spec<'tok, 'src>(
         .map(|attrs| attrs.unwrap_or_default())
         .parse_next(input)?;
 
-    Ok(types::TypeSpec {
+    Ok(TypeSpec {
         type_name,
         attributes,
     })
@@ -459,9 +451,7 @@ fn invocation_type_spec<'tok, 'src>(
 /// Examples:
 /// - `type Button = Rectangle;`
 /// - `type StyledBox = Rectangle[fill_color="blue", border_width="2"];`
-fn type_definition<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<types::TypeDefinition<'src>> {
+fn type_definition<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<TypeDefinition<'src>> {
     any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Type))
         .parse_next(input)?;
 
@@ -480,13 +470,13 @@ fn type_definition<'tok, 'src>(
 
     semicolon.parse_next(input)?;
 
-    Ok(types::TypeDefinition { name, type_spec })
+    Ok(TypeDefinition { name, type_spec })
 }
 
 /// Parse type definitions section
 fn type_definitions<'tok, 'src>(
     input: &mut Input<'tok, 'src>,
-) -> IResult<Vec<types::TypeDefinition<'src>>> {
+) -> IResult<Vec<TypeDefinition<'src>>> {
     repeat(0.., preceded(ws_comments0, type_definition)).parse_next(input)
 }
 
@@ -518,7 +508,7 @@ fn relation_type<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<&'src str
 /// - `container: Box { nested_component: Circle; };`
 /// - `panel: Box embed { diagram sequence; user -> server; };`
 /// - `panel: Box embed auth_flow;`
-fn component<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+fn component<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
     let name = identifier.parse_next(input)?;
 
     ws_comments0.parse_next(input)?;
@@ -546,7 +536,7 @@ fn component<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Elemen
     ws_comments0.parse_next(input)?;
     semicolon.parse_next(input)?;
 
-    Ok(types::Element::Component {
+    Ok(Element::Component {
         name,
         display_name,
         type_spec,
@@ -563,7 +553,7 @@ fn component<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Elemen
 /// - `user -> @AsyncCall server: "Request";`
 /// - `user -> @AsyncCall[color="blue"] server: "Request";`
 /// - `user -> [color="red"] server;` (anonymous TypeSpec)
-fn relation<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+fn relation<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
     let source = nested_identifier.parse_next(input)?;
 
     ws_comments0.parse_next(input)?;
@@ -595,7 +585,7 @@ fn relation<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element
             .context(Context::Label("semicolon after relation"))
             .parse_next(input)?;
 
-        Ok(types::Element::Relation {
+        Ok(Element::Relation {
             source,
             target,
             relation_type: make_spanned(relation_type, Span::new(0..0)), // TODO: track proper span
@@ -617,7 +607,7 @@ fn relation<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element
 ///   (consistent with `Element::span()` semantics using the inner `component` span).
 /// - Whitespace and line comments are allowed between tokens as handled by
 ///   `ws_comments0/1`.
-fn activate_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+fn activate_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
     // Parse "activate" keyword
     any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Activate))
         .context(Context::Label("activate keyword"))
@@ -666,7 +656,7 @@ fn activate_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::E
         .context(Context::Label("semicolon after activate block"))
         .parse_next(input)?;
 
-    Ok(types::Element::ActivateBlock {
+    Ok(Element::ActivateBlock {
         component,
         type_spec,
         elements: nested_elements,
@@ -674,9 +664,7 @@ fn activate_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::E
 }
 
 /// Parse a section block: `section "title" { elements };`
-fn section_block<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<types::FragmentSection<'src>> {
+fn section_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<FragmentSection<'src>> {
     // Parse "section" keyword
     any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Section))
         .context(Context::Label("section keyword"))
@@ -718,7 +706,7 @@ fn section_block<'tok, 'src>(
             .context(Context::Label("semicolon after section"))
             .parse_next(input)?;
 
-        Ok(types::FragmentSection {
+        Ok(FragmentSection {
             title,
             elements: elems,
         })
@@ -730,7 +718,7 @@ fn section_block<'tok, 'src>(
 fn parse_section_content<'tok, 'src>(
     input: &mut Input<'tok, 'src>,
     title_context: &'static str,
-) -> IResult<types::FragmentSection<'src>> {
+) -> IResult<FragmentSection<'src>> {
     ws_comments0.parse_next(input)?;
 
     let title = opt(string_literal.context(Context::Label(title_context))).parse_next(input)?;
@@ -751,7 +739,7 @@ fn parse_section_content<'tok, 'src>(
         .context(Context::Label("closing brace '}'"))
         .parse_next(input)?;
 
-    Ok(types::FragmentSection {
+    Ok(FragmentSection {
         title,
         elements: elems,
     })
@@ -760,7 +748,7 @@ fn parse_section_content<'tok, 'src>(
 /// Macro for generating single-section fragment keyword parsers
 macro_rules! single_section_parser {
     ($fn_name:ident, $token:ident, $title_ctx:expr, $element_variant:ident) => {
-        fn $fn_name<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+        fn $fn_name<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
             let keyword_token = any
                 .verify(|token: &PositionedToken<'_>| matches!(token.token, Token::$token))
                 .context(Context::Label(concat!(stringify!($token), " keyword")))
@@ -785,7 +773,7 @@ macro_rules! single_section_parser {
                     )))
                     .parse_next(input)?;
 
-                Ok(types::Element::$element_variant {
+                Ok(Element::$element_variant {
                     keyword_span,
                     type_spec,
                     section,
@@ -798,7 +786,7 @@ macro_rules! single_section_parser {
 /// Macro for generating multi-section fragment keyword parsers
 macro_rules! multi_section_parser {
     ($fn_name:ident, $first_token:ident, $cont_token:ident, $first_ctx:expr, $cont_ctx:expr, $element_variant:ident) => {
-        fn $fn_name<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+        fn $fn_name<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
             let keyword_token = any
                 .verify(|token: &PositionedToken<'_>| matches!(token.token, Token::$first_token))
                 .context(Context::Label(concat!(
@@ -842,7 +830,7 @@ macro_rules! multi_section_parser {
                     )))
                     .parse_next(input)?;
 
-                Ok(types::Element::$element_variant {
+                Ok(Element::$element_variant {
                     keyword_span,
                     type_spec,
                     sections,
@@ -870,7 +858,7 @@ multi_section_parser!(
 multi_section_parser!(par_block, Par, Par, "par title", "par title", ParBlock);
 
 /// Parse a fragment block: `fragment @TypeSpec "operation" { section+ };`
-fn fragment_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+fn fragment_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
     // Parse "fragment" keyword
     any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Fragment))
         .context(Context::Label("fragment keyword"))
@@ -918,7 +906,7 @@ fn fragment_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::E
             .context(Context::Label("semicolon after fragment"))
             .parse_next(input)?;
 
-        Ok(types::Element::Fragment(types::Fragment {
+        Ok(Element::Fragment(Fragment {
             operation,
             type_spec,
             sections,
@@ -935,7 +923,7 @@ fn fragment_block<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::E
 /// - `@TypeSpec` is optional invocation type spec: `@TypeName[attrs]`, `@TypeName`, or omitted (sugar)
 /// - `<nested_identifier>` supports `::`-qualified component names
 /// - Optional whitespace and line comments are permitted between tokens
-fn activate_statement<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+fn activate_statement<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
     // Parse "activate" keyword
     any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Activate))
         .context(Context::Label("activate keyword"))
@@ -961,16 +949,14 @@ fn activate_statement<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<type
         .context(Context::Label("semicolon after activate statement"))
         .parse_next(input)?;
 
-    Ok(types::Element::Activate {
+    Ok(Element::Activate {
         component,
         type_spec,
     })
 }
 
 /// Parse an explicit deactivate statement: `deactivate <nested_identifier>;`
-fn deactivate_statement<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<types::Element<'src>> {
+fn deactivate_statement<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
     // Parse "deactivate" keyword
     any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Deactivate))
         .context(Context::Label("deactivate keyword"))
@@ -990,7 +976,7 @@ fn deactivate_statement<'tok, 'src>(
         .context(Context::Label("semicolon after deactivate statement"))
         .parse_next(input)?;
 
-    Ok(types::Element::Deactivate { component })
+    Ok(Element::Deactivate { component })
 }
 
 /// Parse an activate element (explicit statement or block) with checkpoint routing
@@ -998,7 +984,7 @@ fn deactivate_statement<'tok, 'src>(
 /// Behavior:
 /// - If an `activate {` block is present, parse the block
 /// - Otherwise, parse an explicit `activate <nested_identifier>;` statement
-fn activate_element<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+fn activate_element<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
     // Try parsing an activate block first; if it fails, reset and parse explicit statement.
     let checkpoint = input.checkpoint();
     match activate_block.parse_next(input) {
@@ -1024,7 +1010,7 @@ fn activate_element<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types:
 /// - `note @NoteType: "Typed note";`
 /// - `note @NoteType[on=[component]]: "Note attached to component";`
 /// - `note [on=[a, b], align="left"]: "Note with anonymous TypeSpec";`
-fn note_element<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Element<'src>> {
+fn note_element<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Element<'src>> {
     // Parse 'note' keyword
     let _ = any
         .verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Note))
@@ -1053,13 +1039,13 @@ fn note_element<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::Ele
     // Parse semicolon
     semicolon.parse_next(input)?;
 
-    Ok(types::Element::Note(types::Note { type_spec, content }))
+    Ok(Element::Note(Note { type_spec, content }))
 }
 /// Parses zero or more diagram elements.
 ///
 /// An invalid-statement catch-all provides better error reporting when no
 /// valid parser matches.
-fn elements<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Vec<types::Element<'src>>> {
+fn elements<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Vec<Element<'src>>> {
     repeat(
         0..,
         preceded(
@@ -1098,7 +1084,7 @@ fn elements<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Vec<types::Ele
 /// Returns Cut error if semicolon found or if meaningful tokens consumed before delimiter.
 fn invalid_statement_with_semicolon<'tok, 'src>(
     input: &mut Input<'tok, 'src>,
-) -> IResult<types::Element<'src>> {
+) -> IResult<Element<'src>> {
     let mut consumed_meaningful_tokens = false;
     let start_offset = input.eof_offset();
 
@@ -1155,7 +1141,7 @@ fn diagram_type<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Spanned<Di
 ///
 /// Consumes the `diagram` keyword, a required [`DiagramKind`], and optional
 /// wrapped attributes.
-fn diagram_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::FileHeader<'src>> {
+fn diagram_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<FileHeader<'src>> {
     any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Diagram))
         .parse_next(input)?;
     ws_comments1.parse_next(input)?;
@@ -1164,24 +1150,24 @@ fn diagram_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::F
     let attributes = opt(wrapped_attributes)
         .map(|attrs| attrs.unwrap_or_default())
         .parse_next(input)?;
-    Ok(types::FileHeader::Diagram { kind, attributes })
+    Ok(FileHeader::Diagram { kind, attributes })
 }
 
 /// Parses a library header: the `library` keyword.
 ///
 /// Consumes only the `library` token itself.
-fn library_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::FileHeader<'src>> {
+fn library_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<FileHeader<'src>> {
     let token = any
         .verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Library))
         .parse_next(input)?;
-    Ok(types::FileHeader::Library { span: token.span })
+    Ok(FileHeader::Library { span: token.span })
 }
 
 /// Parses the file header that begins every `.orr` file.
 ///
 /// Dispatches to [`library_header`] or [`diagram_header`] based on the
 /// leading token, then consumes the required trailing semicolon.
-fn file_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::FileHeader<'src>> {
+fn file_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<FileHeader<'src>> {
     let header = alt((library_header, diagram_header))
         .context(Context::Label("file header"))
         .parse_next(input)?;
@@ -1197,7 +1183,7 @@ fn file_header<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::File
 /// - `import "path";` — namespaced import.
 /// - `import "path" as alias;` — aliased import.
 /// - `import "path"::*;` — glob import.
-fn import_decl<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Spanned<types::ImportDecl>> {
+fn import_decl<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Spanned<ImportDecl>> {
     let import_token = any
         .verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Import))
         .parse_next(input)?;
@@ -1220,7 +1206,7 @@ fn import_decl<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Spanned<typ
                         .context(Context::Label("alias identifier after 'as'"))
                         .parse_next(input)?;
                     let end = alias.span();
-                    Ok((types::ImportForm::Aliased(alias), end))
+                    Ok((ImportForm::Aliased(alias), end))
                 })
             },
             // `::*` → Glob
@@ -1232,24 +1218,22 @@ fn import_decl<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Spanned<typ
                         .verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Star))
                         .context(Context::Label("'*' after '::'"))
                         .parse_next(input)?;
-                    Ok((types::ImportForm::Glob, star.span))
+                    Ok((ImportForm::Glob, star.span))
                 })
             },
             // Nothing → Namespaced
-            |_input: &mut Input<'tok, 'src>| Ok((types::ImportForm::Namespaced, path.span())),
+            |_input: &mut Input<'tok, 'src>| Ok((ImportForm::Namespaced, path.span())),
         ))
         .parse_next(input)?;
 
         semicolon.parse_next(input)?;
         let span = import_token.span.union(end_span);
-        Ok(make_spanned(types::ImportDecl { path, form }, span))
+        Ok(make_spanned(ImportDecl { path, form }, span))
     })
 }
 
 /// Parses zero or more consecutive [`import_decl`] statements.
-fn import_decls<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<Vec<Spanned<types::ImportDecl>>> {
+fn import_decls<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<Vec<Spanned<ImportDecl>>> {
     repeat(0.., preceded(ws_comments0, import_decl)).parse_next(input)
 }
 
@@ -1257,7 +1241,7 @@ fn import_decls<'tok, 'src>(
 ///
 /// Expects the sequence: file header → import declarations → type definitions
 /// → elements.
-fn file<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::FileAst<'src>> {
+fn file<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<FileAst<'src>> {
     ws_comments0.parse_next(input)?;
     let header = file_header.parse_next(input)?;
     let import_decls = import_decls.parse_next(input)?;
@@ -1265,7 +1249,7 @@ fn file<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::FileAst<'sr
     let elements = elements.parse_next(input)?;
     ws_comments0.parse_next(input)?;
 
-    Ok(types::FileAst {
+    Ok(FileAst {
         header,
         import_decls,
         type_definitions,
@@ -1284,9 +1268,7 @@ fn file<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<types::FileAst<'sr
 /// - `ComponentContent::Diagram(...)` — when an `embed` keyword is found.
 /// - `ComponentContent::Scope(...)` — when a `{` brace block is found.
 /// - `ComponentContent::None` — when neither is present.
-fn component_content<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<types::ComponentContent<'src>> {
+fn component_content<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<ComponentContent<'src>> {
     opt(alt((
         // Try parsing embedded diagram first (starts with 'embed' keyword)
         embedded_diagram,
@@ -1302,9 +1284,9 @@ fn component_content<'tok, 'src>(
                 any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::RightBrace)),
             ),
         )
-        .map(types::ComponentContent::Scope),
+        .map(ComponentContent::Scope),
     )))
-    .map(|opt_content| opt_content.unwrap_or(types::ComponentContent::None))
+    .map(|opt_content| opt_content.unwrap_or(ComponentContent::None))
     .parse_next(input)
 }
 
@@ -1318,9 +1300,7 @@ fn component_content<'tok, 'src>(
 ///   → `ComponentContent::Diagram(DiagramSource::Inline(...))`
 /// - `embed auth_flow` — reference to an imported diagram
 ///   → `ComponentContent::Diagram(DiagramSource::Ref(...))`
-fn embedded_diagram<'tok, 'src>(
-    input: &mut Input<'tok, 'src>,
-) -> IResult<types::ComponentContent<'src>> {
+fn embedded_diagram<'tok, 'src>(input: &mut Input<'tok, 'src>) -> IResult<ComponentContent<'src>> {
     // Parse: embed
     any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::Embed))
         .parse_next(input)?;
@@ -1336,12 +1316,10 @@ fn embedded_diagram<'tok, 'src>(
                 any.verify(|token: &PositionedToken<'_>| matches!(token.token, Token::RightBrace)),
             )
             .map(|file_ast| {
-                types::ComponentContent::Diagram(types::DiagramSource::Inline(Rc::new(
-                    RefCell::new(file_ast),
-                )))
+                ComponentContent::Diagram(DiagramSource::Inline(Rc::new(RefCell::new(file_ast))))
             }),
             // Ref: embed <identifier>
-            identifier.map(|id| types::ComponentContent::Diagram(types::DiagramSource::Ref(id))),
+            identifier.map(|id| ComponentContent::Diagram(DiagramSource::Ref(id))),
         ))
         .parse_next(input)
     })
@@ -1451,7 +1429,7 @@ fn convert_error(
     }
 }
 
-/// Parses a token stream into a [`FileAst`](types::FileAst).
+/// Parses a token stream into a [`FileAst`](FileAst).
 ///
 /// This is the public entry point for parsing a complete source file.
 /// After the inner [`file()`] combinator succeeds, this
@@ -1465,16 +1443,14 @@ fn convert_error(
 ///
 /// # Returns
 ///
-/// A [`FileAst`](types::FileAst) on success.
+/// A [`FileAst`](FileAst) on success.
 ///
 /// # Errors
 ///
 /// Returns a [`Diagnostic`] when:
 /// - The token stream does not match the expected Orrery grammar.
 /// - Tokens remain after parsing (unconsumed trailing input).
-pub fn build_file<'src>(
-    tokens: &[PositionedToken<'src>],
-) -> Result<types::FileAst<'src>, Diagnostic> {
+pub fn build_file<'src>(tokens: &[PositionedToken<'src>]) -> Result<FileAst<'src>, Diagnostic> {
     let mut token_slice = TokenSlice::new(tokens);
 
     match file.parse_next(&mut token_slice) {
@@ -1614,7 +1590,7 @@ mod tests {
         assert!(result.is_ok(), "Relation with @TypeName should parse");
 
         match result.unwrap() {
-            types::Element::Relation { type_spec, .. } => {
+            Element::Relation { type_spec, .. } => {
                 assert!(type_spec.type_name.is_some());
                 assert_eq!(*type_spec.type_name.unwrap().inner(), "Arrow");
                 assert!(type_spec.attributes.is_empty());
@@ -1636,7 +1612,7 @@ mod tests {
         );
 
         match result.unwrap() {
-            types::Element::Relation { type_spec, .. } => {
+            Element::Relation { type_spec, .. } => {
                 assert!(type_spec.type_name.is_some());
                 assert_eq!(*type_spec.type_name.unwrap().inner(), "Arrow");
                 assert_eq!(type_spec.attributes.len(), 2);
@@ -1657,7 +1633,7 @@ mod tests {
         assert!(result.is_ok(), "Relation with [attrs] should parse");
 
         match result.unwrap() {
-            types::Element::Relation { type_spec, .. } => {
+            Element::Relation { type_spec, .. } => {
                 assert!(type_spec.type_name.is_none(), "Anonymous type has no name");
                 assert_eq!(type_spec.attributes.len(), 2);
                 assert_eq!(*type_spec.attributes[0].name.inner(), "style");
@@ -1677,7 +1653,7 @@ mod tests {
         assert!(result.is_ok(), "Relation with sugar syntax should parse");
 
         match result.unwrap() {
-            types::Element::Relation { type_spec, .. } => {
+            Element::Relation { type_spec, .. } => {
                 assert!(type_spec.type_name.is_none());
                 assert!(type_spec.attributes.is_empty());
             }
@@ -1697,7 +1673,7 @@ mod tests {
         assert!(elem.is_ok(), "activate statement should parse");
 
         match elem.unwrap() {
-            types::Element::Activate { component, .. } => {
+            Element::Activate { component, .. } => {
                 assert_eq!(*component.inner(), "user");
                 let id_span = first_identifier_span(&tokens);
                 assert_eq!(
@@ -1720,7 +1696,7 @@ mod tests {
         assert!(elem.is_ok(), "deactivate statement should parse");
 
         match elem.unwrap() {
-            types::Element::Deactivate { component } => {
+            Element::Deactivate { component } => {
                 assert_eq!(*component.inner(), "server");
                 let id_span = first_identifier_span(&tokens);
                 assert_eq!(
@@ -1745,7 +1721,7 @@ mod tests {
             "activate with comments/whitespace should parse"
         );
         match elem.unwrap() {
-            types::Element::Activate { component, .. } => {
+            Element::Activate { component, .. } => {
                 assert_eq!(*component.inner(), "user");
             }
             other => panic!("expected Activate element, got {:?}", other),
@@ -1764,7 +1740,7 @@ mod tests {
             "deactivate with comments/whitespace should parse"
         );
         match elem.unwrap() {
-            types::Element::Deactivate { component } => {
+            Element::Deactivate { component } => {
                 assert_eq!(*component.inner(), "user");
             }
             other => panic!("expected Deactivate element, got {:?}", other),
@@ -1800,7 +1776,7 @@ mod tests {
         let elem = activate_statement.parse_next(&mut slice);
         assert!(elem.is_ok(), "activate with nested identifier should parse");
         match elem.unwrap() {
-            types::Element::Activate { component, .. } => {
+            Element::Activate { component, .. } => {
                 assert_eq!(*component.inner(), "parent::child");
                 let expected_span = nested_identifier_span(&tokens);
                 assert_eq!(
@@ -1823,7 +1799,7 @@ mod tests {
         assert!(elem.is_ok(), "activate with type_spec should parse");
 
         match elem.unwrap() {
-            types::Element::Activate {
+            Element::Activate {
                 component,
                 type_spec,
             } => {
@@ -1851,7 +1827,7 @@ mod tests {
         );
 
         match elem.unwrap() {
-            types::Element::Activate {
+            Element::Activate {
                 component,
                 type_spec,
             } => {
@@ -1877,7 +1853,7 @@ mod tests {
         assert!(elem.is_ok(), "activate without type_spec should parse");
 
         match elem.unwrap() {
-            types::Element::Activate {
+            Element::Activate {
                 component,
                 type_spec,
             } => {
@@ -1901,7 +1877,7 @@ mod tests {
             "deactivate with nested identifier should parse"
         );
         match elem.unwrap() {
-            types::Element::Deactivate { component } => {
+            Element::Deactivate { component } => {
                 assert_eq!(*component.inner(), "a::b::c");
                 let expected_span = nested_identifier_span(&tokens);
                 assert_eq!(
@@ -1932,7 +1908,7 @@ mod tests {
         );
 
         let element = result.unwrap();
-        if let types::Element::ActivateBlock {
+        if let Element::ActivateBlock {
             component,
             elements,
             type_spec: _type_spec,
@@ -2127,7 +2103,7 @@ mod tests {
         assert!(result.is_ok());
         let attr = result.unwrap();
         assert_eq!(*attr.name.inner(), "color");
-        assert!(matches!(&attr.value, types::AttributeValue::String(s) if s.inner() == "red"));
+        assert!(matches!(&attr.value, AttributeValue::String(s) if s.inner() == "red"));
 
         // Test that unquoted identifiers are now valid as TypeSpec names
         let tokens = parse_tokens("stroke=RedStroke");
@@ -2136,7 +2112,7 @@ mod tests {
         assert!(result.is_ok());
         let attr = result.unwrap();
         assert_eq!(*attr.name.inner(), "stroke");
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             assert_eq!(*type_spec.type_name.as_ref().unwrap().inner(), "RedStroke");
             assert_eq!(type_spec.attributes.len(), 0);
         } else {
@@ -2150,7 +2126,7 @@ mod tests {
         assert!(result.is_ok());
         let attr = result.unwrap();
         assert_eq!(*attr.name.inner(), "width");
-        assert!(matches!(&attr.value, types::AttributeValue::Float(f) if *f.inner() == 2.5));
+        assert!(matches!(&attr.value, AttributeValue::Float(f) if *f.inner() == 2.5));
     }
 
     #[test]
@@ -2163,16 +2139,16 @@ mod tests {
         let attr = result.unwrap();
         assert_eq!(*attr.name.inner(), "text");
 
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             let nested_attrs = &type_spec.attributes;
             assert_eq!(nested_attrs.len(), 2);
             assert_eq!(*nested_attrs[0].name.inner(), "font_size");
             assert!(
-                matches!(&nested_attrs[0].value, types::AttributeValue::Float(f) if *f.inner() == 12.0)
+                matches!(&nested_attrs[0].value, AttributeValue::Float(f) if *f.inner() == 12.0)
             );
             assert_eq!(*nested_attrs[1].name.inner(), "padding");
             assert!(
-                matches!(&nested_attrs[1].value, types::AttributeValue::Float(f) if *f.inner() == 6.5)
+                matches!(&nested_attrs[1].value, AttributeValue::Float(f) if *f.inner() == 6.5)
             );
         } else {
             panic!("Expected nested attributes");
@@ -2186,7 +2162,7 @@ mod tests {
         let attr = result.unwrap();
         assert_eq!(*attr.name.inner(), "text");
         // Empty brackets [] are parsed as Empty variant
-        if let types::AttributeValue::Empty = &attr.value {
+        if let AttributeValue::Empty = &attr.value {
             // Verify it can be interpreted as empty attributes
             assert_eq!(attr.value.as_type_spec().unwrap().attributes.len(), 0);
         } else {
@@ -2199,12 +2175,12 @@ mod tests {
         let result = attribute(&mut input);
         assert!(result.is_ok());
         let attr = result.unwrap();
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             let nested_attrs = &type_spec.attributes;
             assert_eq!(nested_attrs.len(), 1);
             assert_eq!(*nested_attrs[0].name.inner(), "font_size");
             assert!(
-                matches!(&nested_attrs[0].value, types::AttributeValue::Float(f) if *f.inner() == 16.0)
+                matches!(&nested_attrs[0].value, AttributeValue::Float(f) if *f.inner() == 16.0)
             );
         } else {
             panic!("Expected nested attributes");
@@ -2216,16 +2192,16 @@ mod tests {
         let result = attribute(&mut input);
         assert!(result.is_ok());
         let attr = result.unwrap();
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             let nested_attrs = &type_spec.attributes;
             assert_eq!(nested_attrs.len(), 2);
             assert_eq!(*nested_attrs[0].name.inner(), "font_family");
             assert!(
-                matches!(&nested_attrs[0].value, types::AttributeValue::String(s) if s.inner() == "Arial")
+                matches!(&nested_attrs[0].value, AttributeValue::String(s) if s.inner() == "Arial")
             );
             assert_eq!(*nested_attrs[1].name.inner(), "font_size");
             assert!(
-                matches!(&nested_attrs[1].value, types::AttributeValue::Float(f) if *f.inner() == 14.0)
+                matches!(&nested_attrs[1].value, AttributeValue::Float(f) if *f.inner() == 14.0)
             );
         } else {
             panic!("Expected nested attributes");
@@ -2240,16 +2216,16 @@ mod tests {
         let result = attribute(&mut input);
         assert!(result.is_ok());
         let attr = result.unwrap();
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             let nested_attrs = &type_spec.attributes;
             assert_eq!(nested_attrs.len(), 2);
             assert_eq!(*nested_attrs[0].name.inner(), "font_size");
             assert!(
-                matches!(&nested_attrs[0].value, types::AttributeValue::Float(f) if *f.inner() == 12.0)
+                matches!(&nested_attrs[0].value, AttributeValue::Float(f) if *f.inner() == 12.0)
             );
             assert_eq!(*nested_attrs[1].name.inner(), "padding");
             assert!(
-                matches!(&nested_attrs[1].value, types::AttributeValue::Float(f) if *f.inner() == 6.5)
+                matches!(&nested_attrs[1].value, AttributeValue::Float(f) if *f.inner() == 6.5)
             );
         } else {
             panic!("Expected nested attributes");
@@ -2307,32 +2283,32 @@ mod tests {
         let attr = result.unwrap();
         assert_eq!(*attr.name.inner(), "text");
 
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             let nested_attrs = &type_spec.attributes;
             assert_eq!(nested_attrs.len(), 4);
 
             // Check font_size
             assert_eq!(*nested_attrs[0].name.inner(), "font_size");
             assert!(
-                matches!(&nested_attrs[0].value, types::AttributeValue::Float(f) if *f.inner() == 16.0)
+                matches!(&nested_attrs[0].value, AttributeValue::Float(f) if *f.inner() == 16.0)
             );
 
             // Check font_family
             assert_eq!(*nested_attrs[1].name.inner(), "font_family");
             assert!(
-                matches!(&nested_attrs[1].value, types::AttributeValue::String(s) if s.inner() == "Arial")
+                matches!(&nested_attrs[1].value, AttributeValue::String(s) if s.inner() == "Arial")
             );
 
             // Check background_color (simplified name)
             assert_eq!(*nested_attrs[2].name.inner(), "background_color");
             assert!(
-                matches!(&nested_attrs[2].value, types::AttributeValue::String(s) if s.inner() == "white")
+                matches!(&nested_attrs[2].value, AttributeValue::String(s) if s.inner() == "white")
             );
 
             // Check padding (simplified name)
             assert_eq!(*nested_attrs[3].name.inner(), "padding");
             assert!(
-                matches!(&nested_attrs[3].value, types::AttributeValue::Float(f) if *f.inner() == 8.0)
+                matches!(&nested_attrs[3].value, AttributeValue::Float(f) if *f.inner() == 8.0)
             );
         } else {
             panic!("Expected nested text attributes");
@@ -2350,7 +2326,7 @@ mod tests {
         let attr = result.unwrap();
         assert_eq!(*attr.name.inner(), "text");
         // Empty brackets [] are parsed as Empty variant
-        if let types::AttributeValue::Empty = &attr.value {
+        if let AttributeValue::Empty = &attr.value {
             // Verify it can be interpreted as empty attributes
             assert_eq!(attr.value.as_type_spec().unwrap().attributes.len(), 0);
         } else {
@@ -2363,12 +2339,12 @@ mod tests {
         let result = attribute(&mut input);
         assert!(result.is_ok());
         let attr = result.unwrap();
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             let nested_attrs = &type_spec.attributes;
             assert_eq!(nested_attrs.len(), 1);
             assert_eq!(*nested_attrs[0].name.inner(), "font_size");
             assert!(
-                matches!(&nested_attrs[0].value, types::AttributeValue::Float(f) if *f.inner() == 20.0)
+                matches!(&nested_attrs[0].value, AttributeValue::Float(f) if *f.inner() == 20.0)
             );
         } else {
             panic!("Expected single text attribute");
@@ -2380,7 +2356,7 @@ mod tests {
         let result = attribute(&mut input);
         assert!(result.is_ok());
         let attr = result.unwrap();
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             let nested_attrs = &type_spec.attributes;
             assert_eq!(nested_attrs.len(), 2);
             assert_eq!(*nested_attrs[0].name.inner(), "font_size");
@@ -2401,39 +2377,27 @@ mod tests {
         assert!(result.is_ok());
         let attr = result.unwrap();
 
-        if let types::AttributeValue::TypeSpec(type_spec) = &attr.value {
+        if let AttributeValue::TypeSpec(type_spec) = &attr.value {
             let nested_attrs = &type_spec.attributes;
             assert_eq!(nested_attrs.len(), 4);
 
             // Verify each attribute type
-            assert!(matches!(
-                &nested_attrs[0].value,
-                types::AttributeValue::Float(_)
-            )); // font_size
-            assert!(matches!(
-                &nested_attrs[1].value,
-                types::AttributeValue::String(_)
-            )); // font_family
-            assert!(matches!(
-                &nested_attrs[2].value,
-                types::AttributeValue::String(_)
-            )); // background_color
-            assert!(matches!(
-                &nested_attrs[3].value,
-                types::AttributeValue::Float(_)
-            )); // padding
+            assert!(matches!(&nested_attrs[0].value, AttributeValue::Float(_))); // font_size
+            assert!(matches!(&nested_attrs[1].value, AttributeValue::String(_))); // font_family
+            assert!(matches!(&nested_attrs[2].value, AttributeValue::String(_))); // background_color
+            assert!(matches!(&nested_attrs[3].value, AttributeValue::Float(_))); // padding
 
             // Verify specific values
-            if let types::AttributeValue::Float(f) = &nested_attrs[0].value {
+            if let AttributeValue::Float(f) = &nested_attrs[0].value {
                 assert_eq!(*f.inner(), 12.0);
             }
-            if let types::AttributeValue::String(s) = &nested_attrs[1].value {
+            if let AttributeValue::String(s) = &nested_attrs[1].value {
                 assert_eq!(s.inner(), "Courier");
             }
-            if let types::AttributeValue::String(s) = &nested_attrs[2].value {
+            if let AttributeValue::String(s) = &nested_attrs[2].value {
                 assert_eq!(s.inner(), "#ff0000");
             }
-            if let types::AttributeValue::Float(f) = &nested_attrs[3].value {
+            if let AttributeValue::Float(f) = &nested_attrs[3].value {
                 assert_eq!(*f.inner(), 5.5);
             }
         } else {
@@ -2527,7 +2491,7 @@ mod tests {
         assert_eq!(spec.attributes.len(), 1);
         assert_eq!(*spec.attributes[0].name.inner(), "text");
         match &spec.attributes[0].value {
-            types::AttributeValue::TypeSpec(type_spec) => {
+            AttributeValue::TypeSpec(type_spec) => {
                 let nested = &type_spec.attributes;
                 assert_eq!(nested.len(), 2);
                 assert_eq!(*nested[0].name.inner(), "font");
@@ -2606,7 +2570,7 @@ mod tests {
         assert_eq!(spec.attributes.len(), 1);
         assert_eq!(*spec.attributes[0].name.inner(), "stroke");
         match &spec.attributes[0].value {
-            types::AttributeValue::TypeSpec(type_spec) => {
+            AttributeValue::TypeSpec(type_spec) => {
                 let nested = &type_spec.attributes;
                 assert_eq!(nested.len(), 2);
                 assert_eq!(*nested[0].name.inner(), "color");
@@ -2652,7 +2616,7 @@ mod tests {
         assert!(spec.type_name.is_none());
         assert_eq!(spec.attributes.len(), 1);
         match &spec.attributes[0].value {
-            types::AttributeValue::TypeSpec(type_spec) => {
+            AttributeValue::TypeSpec(type_spec) => {
                 let nested = &type_spec.attributes;
                 assert_eq!(nested.len(), 2);
             }
@@ -2788,7 +2752,7 @@ mod tests {
         assert!(result.is_ok(), "Empty activate block should be valid");
 
         let element = result.unwrap();
-        if let types::Element::ActivateBlock {
+        if let Element::ActivateBlock {
             component,
             elements,
             type_spec: _type_spec,
@@ -2816,7 +2780,7 @@ mod tests {
         assert!(result.is_ok(), "Nested activate blocks should be valid");
 
         let element = result.unwrap();
-        if let types::Element::ActivateBlock {
+        if let Element::ActivateBlock {
             component,
             elements,
             type_spec: _type_spec,
@@ -2828,7 +2792,7 @@ mod tests {
             // Verify nested activate block exists
             let has_nested_activate = elements
                 .iter()
-                .any(|el| matches!(el, types::Element::ActivateBlock { .. }));
+                .any(|el| matches!(el, Element::ActivateBlock { .. }));
             assert!(has_nested_activate, "Should contain nested activate block");
         } else {
             panic!("Expected ActivateBlock element");
@@ -2851,7 +2815,7 @@ mod tests {
         );
 
         let element = result.unwrap();
-        if let types::Element::ActivateBlock {
+        if let Element::ActivateBlock {
             component,
             elements,
             type_spec: _type_spec,
@@ -2878,7 +2842,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse opt block: {:?}", result);
 
         let element = result.unwrap();
-        if let types::Element::OptBlock {
+        if let Element::OptBlock {
             keyword_span,
             section,
             type_spec,
@@ -2908,7 +2872,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse opt block with attributes");
 
         let element = result.unwrap();
-        if let types::Element::OptBlock { type_spec, .. } = element {
+        if let Element::OptBlock { type_spec, .. } = element {
             assert_eq!(type_spec.attributes.len(), 2);
         } else {
             panic!("Expected OptBlock element");
@@ -2927,7 +2891,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse opt block without title");
 
         let element = result.unwrap();
-        if let types::Element::OptBlock { section, .. } = element {
+        if let Element::OptBlock { section, .. } = element {
             assert!(section.title.is_none());
         } else {
             panic!("Expected OptBlock element");
@@ -2946,7 +2910,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse loop block: {:?}", result);
 
         let element = result.unwrap();
-        if let types::Element::LoopBlock {
+        if let Element::LoopBlock {
             keyword_span,
             section,
             ..
@@ -2972,7 +2936,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse break block: {:?}", result);
 
         let element = result.unwrap();
-        if let types::Element::BreakBlock {
+        if let Element::BreakBlock {
             keyword_span,
             section,
             ..
@@ -3001,7 +2965,7 @@ mod tests {
         );
 
         let element = result.unwrap();
-        if let types::Element::CriticalBlock {
+        if let Element::CriticalBlock {
             keyword_span,
             section,
             ..
@@ -3034,7 +2998,7 @@ mod tests {
         );
 
         let element = result.unwrap();
-        if let types::Element::AltElseBlock {
+        if let Element::AltElseBlock {
             keyword_span,
             sections,
             ..
@@ -3065,7 +3029,7 @@ mod tests {
         );
 
         let element = result.unwrap();
-        if let types::Element::AltElseBlock { sections, .. } = element {
+        if let Element::AltElseBlock { sections, .. } = element {
             assert_eq!(sections.len(), 1);
         } else {
             panic!("Expected AltElseBlock element");
@@ -3086,7 +3050,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse par block: {:?}", result);
 
         let element = result.unwrap();
-        if let types::Element::ParBlock {
+        if let Element::ParBlock {
             keyword_span,
             sections,
             ..
@@ -3116,7 +3080,7 @@ mod tests {
         );
 
         let element = result.unwrap();
-        if let types::Element::ParBlock { sections, .. } = element {
+        if let Element::ParBlock { sections, .. } = element {
             assert_eq!(sections.len(), 1);
         } else {
             panic!("Expected ParBlock element");
@@ -3139,10 +3103,10 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse nested fragment keywords");
 
         let element = result.unwrap();
-        if let types::Element::OptBlock { section, .. } = element {
+        if let Element::OptBlock { section, .. } = element {
             assert_eq!(section.elements.len(), 1);
             // Inner element should be an AltElseBlock
-            if let types::Element::AltElseBlock { .. } = &section.elements[0] {
+            if let Element::AltElseBlock { .. } = &section.elements[0] {
                 // Success
             } else {
                 panic!("Expected nested AltElseBlock");
@@ -3163,7 +3127,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse opt block with empty body");
 
         let element = result.unwrap();
-        if let types::Element::OptBlock { section, .. } = element {
+        if let Element::OptBlock { section, .. } = element {
             assert_eq!(section.elements.len(), 0);
         } else {
             panic!("Expected OptBlock element");
@@ -3180,7 +3144,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse simple note element");
 
         let element = result.unwrap();
-        if let types::Element::Note(note) = element {
+        if let Element::Note(note) = element {
             assert_eq!(note.type_spec.attributes.len(), 0);
             assert_eq!(note.content.inner(), "This is a simple note");
         } else {
@@ -3198,7 +3162,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse note with attributes");
 
         let element = result.unwrap();
-        if let types::Element::Note(note) = element {
+        if let Element::Note(note) = element {
             assert_eq!(note.type_spec.attributes.len(), 1);
             assert_eq!(*note.type_spec.attributes[0].name.inner(), "align");
             assert_eq!(note.content.inner(), "Note with attributes");
@@ -3217,7 +3181,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse note with @TypeName");
 
         let element = result.unwrap();
-        if let types::Element::Note(note) = element {
+        if let Element::Note(note) = element {
             assert!(note.type_spec.type_name.is_some());
             assert_eq!(*note.type_spec.type_name.unwrap().inner(), "WarningNote");
             assert!(note.type_spec.attributes.is_empty());
@@ -3237,7 +3201,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse note with @TypeName[attrs]");
 
         let element = result.unwrap();
-        if let types::Element::Note(note) = element {
+        if let Element::Note(note) = element {
             assert!(note.type_spec.type_name.is_some());
             assert_eq!(*note.type_spec.type_name.unwrap().inner(), "InfoNote");
             assert_eq!(note.type_spec.attributes.len(), 2);
@@ -3286,7 +3250,7 @@ mod tests {
         );
 
         let element = result.unwrap();
-        if let types::Element::Note(note) = &element {
+        if let Element::Note(note) = &element {
             assert_eq!(note.type_spec.attributes.len(), 1);
             assert_eq!(*note.type_spec.attributes[0].name.inner(), "align");
             assert_eq!(note.content.inner(), "Content with spacing");
@@ -3509,15 +3473,15 @@ mod tests {
         let note_count = file_ast
             .elements
             .iter()
-            .filter(|e| matches!(e, types::Element::Note(_)))
+            .filter(|e| matches!(e, Element::Note(_)))
             .count();
         assert_eq!(note_count, 4, "Expected 4 notes in diagram");
 
         // Verify first note is a margin note with no attributes
-        if let Some(types::Element::Note(note)) = file_ast
+        if let Some(Element::Note(note)) = file_ast
             .elements
             .iter()
-            .find(|e| matches!(e, types::Element::Note(_)))
+            .find(|e| matches!(e, Element::Note(_)))
         {
             assert_eq!(note.content.inner(), "This is a margin note");
             assert_eq!(
@@ -3534,7 +3498,7 @@ mod tests {
             .elements
             .iter()
             .filter_map(|e| match e {
-                types::Element::Note(note) => Some(note),
+                Element::Note(note) => Some(note),
                 _ => None,
             })
             .filter(|note| {
@@ -3561,7 +3525,7 @@ mod tests {
         let result = attribute_value(&mut token_slice);
         assert!(result.is_ok(), "Failed to parse empty brackets");
 
-        if let types::AttributeValue::Empty = result.unwrap() {
+        if let AttributeValue::Empty = result.unwrap() {
             // Success
         } else {
             panic!("Expected Empty attribute value");
@@ -3642,10 +3606,10 @@ mod tests {
             assert!(result.is_ok(), "Failed for {input}: {:?}", result.err());
             let file_ast = result.unwrap();
             match &file_ast.header {
-                types::FileHeader::Diagram { kind, .. } => {
+                FileHeader::Diagram { kind, .. } => {
                     assert_eq!(*kind.inner(), expected_kind, "Wrong kind for {input}");
                 }
-                types::FileHeader::Library { .. } => {
+                FileHeader::Library { .. } => {
                     panic!("Expected Diagram header for {input}")
                 }
             }
@@ -3664,12 +3628,12 @@ mod tests {
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         let file_ast = result.unwrap();
         match &file_ast.header {
-            types::FileHeader::Diagram { kind, attributes } => {
+            FileHeader::Diagram { kind, attributes } => {
                 assert_eq!(*kind.inner(), DiagramKind::Component);
                 assert_eq!(attributes.len(), 1);
                 assert_eq!(*attributes[0].name.inner(), "layout_engine");
             }
-            types::FileHeader::Library { .. } => panic!("Expected Diagram header"),
+            FileHeader::Library { .. } => panic!("Expected Diagram header"),
         }
     }
 
@@ -3680,7 +3644,7 @@ mod tests {
         let result = build_file(&tokens);
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         let file_ast = result.unwrap();
-        assert!(matches!(file_ast.header, types::FileHeader::Library { .. }));
+        assert!(matches!(file_ast.header, FileHeader::Library { .. }));
         assert!(file_ast.import_decls.is_empty());
         assert!(file_ast.type_definitions.is_empty());
         assert!(file_ast.elements.is_empty());
@@ -3696,7 +3660,7 @@ type Database = Rectangle;"#;
         let result = build_file(&tokens);
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         let file_ast = result.unwrap();
-        assert!(matches!(file_ast.header, types::FileHeader::Library { .. }));
+        assert!(matches!(file_ast.header, FileHeader::Library { .. }));
         assert_eq!(file_ast.type_definitions.len(), 2);
         assert!(file_ast.elements.is_empty());
     }
@@ -3712,7 +3676,7 @@ type Database = Rectangle;"#;
         let result = build_file(&tokens);
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         let file_ast = result.unwrap();
-        assert!(matches!(file_ast.header, types::FileHeader::Library { .. }));
+        assert!(matches!(file_ast.header, FileHeader::Library { .. }));
         assert_eq!(file_ast.import_decls.len(), 2);
         assert_eq!(
             *file_ast.import_decls[0].inner().path.inner(),
@@ -3741,7 +3705,7 @@ import "shared/styles";"#;
         );
         assert_eq!(
             file_ast.import_decls[0].inner().form,
-            types::ImportForm::Namespaced
+            ImportForm::Namespaced
         );
     }
 
@@ -3825,7 +3789,7 @@ import "path/to/file";"#;
         assert_eq!(file_ast.import_decls.len(), 1);
         assert_eq!(
             file_ast.import_decls[0].inner().form,
-            types::ImportForm::Namespaced
+            ImportForm::Namespaced
         );
         // import(19..25) union "path/to/file"(26..40) = 19..40
         assert_eq!(file_ast.import_decls[0].span(), Span::from(19..40));
@@ -3842,7 +3806,7 @@ import "shared/styles"::*;"#;
         assert_eq!(file_ast.import_decls.len(), 1);
         let import = file_ast.import_decls[0].inner();
         assert_eq!(*import.path.inner(), "shared/styles");
-        assert_eq!(import.form, types::ImportForm::Glob);
+        assert_eq!(import.form, ImportForm::Glob);
         // import(19..25) union *(43..44) = 19..44
         assert_eq!(file_ast.import_decls[0].span(), Span::from(19..44));
     }
@@ -3857,14 +3821,8 @@ import "common/types"::*;"#;
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         let file_ast = result.unwrap();
         assert_eq!(file_ast.import_decls.len(), 2);
-        assert_eq!(
-            file_ast.import_decls[0].inner().form,
-            types::ImportForm::Glob
-        );
-        assert_eq!(
-            file_ast.import_decls[1].inner().form,
-            types::ImportForm::Glob
-        );
+        assert_eq!(file_ast.import_decls[0].inner().form, ImportForm::Glob);
+        assert_eq!(file_ast.import_decls[1].inner().form, ImportForm::Glob);
     }
 
     #[test]
@@ -3877,10 +3835,7 @@ type Service = Rectangle;"#;
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         let file_ast = result.unwrap();
         assert_eq!(file_ast.import_decls.len(), 1);
-        assert_eq!(
-            file_ast.import_decls[0].inner().form,
-            types::ImportForm::Glob
-        );
+        assert_eq!(file_ast.import_decls[0].inner().form, ImportForm::Glob);
         assert_eq!(file_ast.type_definitions.len(), 1);
     }
 
@@ -3898,7 +3853,7 @@ import "shared/styles" as theme;"#;
         // import(19..25) union theme(45..50) = 19..50
         assert_eq!(import.span(), Span::from(19..50));
         match &import.inner().form {
-            types::ImportForm::Aliased(alias) => {
+            ImportForm::Aliased(alias) => {
                 assert_eq!(*alias.inner(), Id::new("theme"));
                 assert_eq!(alias.span(), Span::from(45..50));
             }
@@ -3919,18 +3874,15 @@ import "base/utils"::*;"#;
         assert_eq!(file_ast.import_decls.len(), 3);
         assert_eq!(
             file_ast.import_decls[0].inner().form,
-            types::ImportForm::Namespaced
+            ImportForm::Namespaced
         );
         match &file_ast.import_decls[1].inner().form {
-            types::ImportForm::Aliased(alias) => {
+            ImportForm::Aliased(alias) => {
                 assert_eq!(*alias.inner(), Id::new("ct"));
             }
             other => panic!("Expected Aliased, got {:?}", other),
         }
-        assert_eq!(
-            file_ast.import_decls[2].inner().form,
-            types::ImportForm::Glob
-        );
+        assert_eq!(file_ast.import_decls[2].inner().form, ImportForm::Glob);
     }
 
     #[test]
@@ -3982,8 +3934,8 @@ a: Rectangle embed {
         let outer_elements = &file_ast.elements;
         assert_eq!(outer_elements.len(), 1);
         match &outer_elements[0] {
-            types::Element::Component { content, .. } => match &content {
-                types::ComponentContent::Diagram(types::DiagramSource::Inline(rc)) => {
+            Element::Component { content, .. } => match &content {
+                ComponentContent::Diagram(DiagramSource::Inline(rc)) => {
                     let inner_file = rc.borrow();
                     assert_eq!(inner_file.import_decls.len(), 1);
                     assert_eq!(
@@ -4008,10 +3960,10 @@ a: Rectangle embed {
         let file_ast = result.unwrap();
         assert_eq!(file_ast.elements.len(), 1);
         match &file_ast.elements[0] {
-            types::Element::Component { name, content, .. } => {
+            Element::Component { name, content, .. } => {
                 assert_eq!(*name.inner(), "auth_box");
                 match content {
-                    types::ComponentContent::Diagram(types::DiagramSource::Ref(id)) => {
+                    ComponentContent::Diagram(DiagramSource::Ref(id)) => {
                         assert_eq!(*id.inner(), "auth_flow");
                     }
                     other => panic!("Expected DiagramSource::Ref, got: {:?}", other),
@@ -4035,12 +3987,9 @@ a: Rectangle embed {
 
         // First element: embed ref
         match &file_ast.elements[0] {
-            types::Element::Component { content, .. } => {
+            Element::Component { content, .. } => {
                 assert!(
-                    matches!(
-                        content,
-                        types::ComponentContent::Diagram(types::DiagramSource::Ref(_))
-                    ),
+                    matches!(content, ComponentContent::Diagram(DiagramSource::Ref(_))),
                     "Expected DiagramSource::Ref for box1"
                 );
             }
@@ -4049,12 +3998,9 @@ a: Rectangle embed {
 
         // Second element: embed inline
         match &file_ast.elements[1] {
-            types::Element::Component { content, .. } => {
+            Element::Component { content, .. } => {
                 assert!(
-                    matches!(
-                        content,
-                        types::ComponentContent::Diagram(types::DiagramSource::Inline(_))
-                    ),
+                    matches!(content, ComponentContent::Diagram(DiagramSource::Inline(_))),
                     "Expected DiagramSource::Inline for box2"
                 );
             }
@@ -4152,7 +4098,7 @@ api -> db;"#;
         let file_ast = result.unwrap();
         assert!(matches!(
             file_ast.header,
-            types::FileHeader::Diagram { ref kind, .. } if *kind.inner() == DiagramKind::Component
+            FileHeader::Diagram { ref kind, .. } if *kind.inner() == DiagramKind::Component
         ));
         assert_eq!(file_ast.import_decls.len(), 2);
         assert_eq!(file_ast.type_definitions.len(), 2);
@@ -4170,7 +4116,7 @@ type Cache = Rectangle;"#;
         let result = build_file(&tokens);
         assert!(result.is_ok(), "Failed: {:?}", result.err());
         let file_ast = result.unwrap();
-        assert!(matches!(file_ast.header, types::FileHeader::Library { .. }));
+        assert!(matches!(file_ast.header, FileHeader::Library { .. }));
         assert_eq!(file_ast.import_decls.len(), 1);
         assert_eq!(file_ast.type_definitions.len(), 3);
         assert!(file_ast.elements.is_empty());

--- a/crates/orrery/src/error.rs
+++ b/crates/orrery/src/error.rs
@@ -3,8 +3,6 @@
 //! This module provides the error type [`RenderError`] for the render pipeline
 //! (graph construction, layout, and export).
 
-use std::io;
-
 use thiserror::Error;
 
 /// The main error type for Orrery runtime operations.
@@ -14,7 +12,7 @@ use thiserror::Error;
 pub enum RenderError {
     /// An I/O error from file operations.
     #[error("I/O error: {0}")]
-    Io(#[from] io::Error),
+    Io(#[from] std::io::Error),
 
     /// A graph construction error.
     #[error("Graph error: {0}")]

--- a/crates/orrery/src/export/svg.rs
+++ b/crates/orrery/src/export/svg.rs
@@ -17,16 +17,21 @@ use orrery_core::{
     color::Color,
     draw::ArrowWithTextDrawer,
     geometry::{Insets, Size},
-    semantic,
+    semantic::Diagram,
 };
 
-use crate::{config::StyleConfig, error::RenderError, export, layout::layer::LayeredLayout};
+use crate::{
+    config::StyleConfig,
+    error::RenderError,
+    export::{Error, Exporter},
+    layout::layer::LayeredLayout,
+};
 
 /// SVG exporter builder to configure and build the SVG exporter.
 pub struct SvgBuilder<'a> {
     file_name: String,
     style: Option<&'a StyleConfig>,
-    diagram: Option<&'a semantic::Diagram>,
+    diagram: Option<&'a Diagram>,
 }
 
 /// Base SVG exporter structure with common properties and methods.
@@ -65,7 +70,7 @@ impl<'a> SvgBuilder<'a> {
     /// # Arguments
     ///
     /// * `diagram` - The semantic diagram.
-    pub fn with_diagram(mut self, diagram: &'a semantic::Diagram) -> Self {
+    pub fn with_diagram(mut self, diagram: &'a Diagram) -> Self {
         self.diagram = Some(diagram);
         self
     }
@@ -157,21 +162,21 @@ impl Svg {
     /// # Errors
     ///
     /// Returns [`export::Error::Io`] if file creation or writing fails.
-    pub fn write_document(&self, doc: Document) -> Result<(), export::Error> {
+    pub fn write_document(&self, doc: Document) -> Result<(), Error> {
         info!(file_name = self.file_name; "Creating SVG file");
         // Create the output file
         let f = match File::create(&self.file_name) {
             Ok(file) => file,
             Err(err) => {
                 error!(file_name=self.file_name, err:err; "Failed to create SVG file");
-                return Err(export::Error::Io(err));
+                return Err(Error::Io(err));
             }
         };
 
         // Write the SVG content to the file
         if let Err(err) = write!(&f, "{doc}") {
             error!(file_name=self.file_name, err:err; "Failed to write SVG content");
-            return Err(export::Error::Io(err));
+            return Err(Error::Io(err));
         }
 
         Ok(())
@@ -179,8 +184,8 @@ impl Svg {
 }
 
 // Implementation of Exporter trait for SVG
-impl export::Exporter for Svg {
-    fn export_layered_layout(&mut self, layout: &LayeredLayout) -> Result<(), export::Error> {
+impl Exporter for Svg {
+    fn export_layered_layout(&mut self, layout: &LayeredLayout) -> Result<(), Error> {
         let doc = self.render_layered_layout(layout);
         debug!("SVG document rendered for layered layout");
 

--- a/crates/orrery/src/export/svg/component.rs
+++ b/crates/orrery/src/export/svg/component.rs
@@ -1,27 +1,30 @@
 //! SVG rendering for component diagrams.
 
 use orrery_core::{
-    draw::{self, LayeredOutput},
+    draw::{LayeredOutput, PositionedArrowWithText},
     geometry::Bounds,
 };
 
 use super::Svg;
-use crate::{layout::component, layout::layer::ContentStack};
+use crate::layout::{
+    component::{Component, Layout},
+    layer::ContentStack,
+};
 
 impl Svg {
     /// Renders a positioned component to layered SVG output.
-    pub fn render_component(&self, component: &component::Component) -> LayeredOutput {
+    pub fn render_component(&self, component: &Component) -> LayeredOutput {
         component.drawable().render_to_layers()
     }
 
     /// Renders a positioned relation arrow to layered SVG output.
-    pub fn render_relation(&mut self, relation: &draw::PositionedArrowWithText) -> LayeredOutput {
+    pub fn render_relation(&mut self, relation: &PositionedArrowWithText) -> LayeredOutput {
         relation.render_to_layers(&mut self.arrow_with_text_drawer)
     }
 
     pub fn calculate_component_diagram_bounds(
         &self,
-        content_stack: &ContentStack<component::Layout>,
+        content_stack: &ContentStack<Layout>,
     ) -> Bounds {
         let last_positioned_content = content_stack.iter().last();
         last_positioned_content

--- a/crates/orrery/src/export/svg/sequence.rs
+++ b/crates/orrery/src/export/svg/sequence.rs
@@ -1,7 +1,7 @@
 //! SVG rendering for sequence diagrams.
 
 use orrery_core::{
-    draw::{self, Drawable as _, LayeredOutput},
+    draw::{Drawable, Fragment, LayeredOutput, Note, PositionedArrowWithText, PositionedDrawable},
     geometry::Bounds,
 };
 
@@ -26,7 +26,7 @@ impl Svg {
     }
 
     /// Renders a positioned message arrow to layered SVG output.
-    pub fn render_message(&mut self, message: &draw::PositionedArrowWithText) -> LayeredOutput {
+    pub fn render_message(&mut self, message: &PositionedArrowWithText) -> LayeredOutput {
         message.render_to_layers(&mut self.arrow_with_text_drawer)
     }
 
@@ -41,10 +41,7 @@ impl Svg {
     /// # Returns
     ///
     /// A [`LayeredOutput`] representing the fragment.
-    pub fn render_fragment(
-        &self,
-        fragment: &draw::PositionedDrawable<draw::Fragment>,
-    ) -> LayeredOutput {
+    pub fn render_fragment(&self, fragment: &PositionedDrawable<Fragment>) -> LayeredOutput {
         fragment.render_to_layers()
     }
 
@@ -59,7 +56,7 @@ impl Svg {
     /// # Returns
     ///
     /// A [`LayeredOutput`] representing the note.
-    pub fn render_note(&self, note: &draw::PositionedDrawable<draw::Note>) -> LayeredOutput {
+    pub fn render_note(&self, note: &PositionedDrawable<Note>) -> LayeredOutput {
         note.render_to_layers()
     }
 

--- a/crates/orrery/src/layout.rs
+++ b/crates/orrery/src/layout.rs
@@ -29,10 +29,11 @@
 //! - [`EngineBuilder`] - Builder for creating and configuring layout engines
 
 pub mod component;
-mod engines;
 pub mod layer;
 pub mod positioning;
 pub mod sequence;
+
+mod engines;
 
 // Public re-export of the engine builder for easier access
 pub use engines::EngineBuilder;

--- a/crates/orrery/src/layout/component.rs
+++ b/crates/orrery/src/layout/component.rs
@@ -10,16 +10,18 @@ use std::{collections::HashMap, rc::Rc};
 use log::{debug, error};
 
 use orrery_core::{
-    draw,
+    draw::{
+        Arrow, ArrowPath, ArrowWithText, PositionedArrowWithText, PositionedDrawable, ShapeWithText,
+    },
     geometry::{Bounds, Point},
     identifier::Id,
-    semantic,
+    semantic::{Node, Relation},
 };
 
 use crate::{
     error::RenderError,
-    layout::{layer, positioning::LayoutBounds},
-    structure,
+    layout::{layer::ContentStack, positioning::LayoutBounds},
+    structure::ComponentGraph,
 };
 
 // TODO: Do I need Clone?!
@@ -27,19 +29,14 @@ use crate::{
 /// A positioned diagram component linking a semantic node to its rendered shape and location.
 #[derive(Debug, Clone)]
 pub struct Component<'a> {
-    node_id: Id, // TODO: Can I get rid of this?
-    drawable: Rc<draw::PositionedDrawable<draw::ShapeWithText<'a>>>, // TODO: Consider removing Rc.
+    node_id: Id,                                         // TODO: Can I get rid of this?
+    drawable: Rc<PositionedDrawable<ShapeWithText<'a>>>, // TODO: Consider removing Rc.
 }
 
 impl<'a> Component<'a> {
     /// Creates a new component with the specified properties.
-    pub fn new(
-        node: &semantic::Node,
-        shape_with_text: draw::ShapeWithText<'a>,
-        position: Point,
-    ) -> Component<'a> {
-        let drawable =
-            Rc::new(draw::PositionedDrawable::new(shape_with_text).with_position(position));
+    pub fn new(node: &Node, shape_with_text: ShapeWithText<'a>, position: Point) -> Component<'a> {
+        let drawable = Rc::new(PositionedDrawable::new(shape_with_text).with_position(position));
         Component {
             node_id: node.id(),
             drawable,
@@ -47,7 +44,7 @@ impl<'a> Component<'a> {
     }
 
     /// Returns a reference to the component's shape.
-    pub fn drawable(&self) -> &draw::PositionedDrawable<draw::ShapeWithText<'_>> {
+    pub fn drawable(&self) -> &PositionedDrawable<ShapeWithText<'_>> {
         &self.drawable
     }
 
@@ -105,10 +102,10 @@ pub trait ArrowPlacer {
     /// Places a bucket of relations between the same component pair.
     fn place<'a>(
         &self,
-        relations: &[&'a semantic::Relation],
+        relations: &[&'a Relation],
         source: &Component<'_>,
         target: &Component<'_>,
-    ) -> Vec<draw::PositionedArrowWithText<'a>>;
+    ) -> Vec<PositionedArrowWithText<'a>>;
 }
 
 /// [`ArrowPlacer`] that emits a straight centerline path for every relation.
@@ -121,29 +118,29 @@ pub struct StraightArrowPlacer;
 impl StraightArrowPlacer {
     /// Straight-line arrow from `source` boundary to `target` boundary.
     fn place_one<'a>(
-        relation: &'a semantic::Relation,
+        relation: &'a Relation,
         source: &Component<'_>,
         target: &Component<'_>,
-    ) -> draw::PositionedArrowWithText<'a> {
+    ) -> PositionedArrowWithText<'a> {
         let arrow_def = Rc::clone(relation.arrow_definition());
-        let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
-        let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
+        let arrow = Arrow::new(arrow_def, relation.arrow_direction());
+        let arrow_with_text = ArrowWithText::new(arrow, relation.text());
 
         let source_edge = source.find_intersection(target.position());
         let target_edge = target.find_intersection(source.position());
-        let path = draw::ArrowPath::straight(source_edge, target_edge);
+        let path = ArrowPath::straight(source_edge, target_edge);
 
-        draw::PositionedArrowWithText::new(arrow_with_text, path)
+        PositionedArrowWithText::new(arrow_with_text, path)
     }
 }
 
 impl ArrowPlacer for StraightArrowPlacer {
     fn place<'a>(
         &self,
-        relations: &[&'a semantic::Relation],
+        relations: &[&'a Relation],
         source: &Component<'_>,
         target: &Component<'_>,
-    ) -> Vec<draw::PositionedArrowWithText<'a>> {
+    ) -> Vec<PositionedArrowWithText<'a>> {
         relations
             .iter()
             .map(|relation| {
@@ -189,24 +186,23 @@ impl CurvedArrowPlacer {
         }
     }
 
-    /// Packages `lane_geometry` output into a [`PositionedArrowWithText`](draw::PositionedArrowWithText).
+    /// Packages `lane_geometry` output into a [`PositionedArrowWithText`](PositionedArrowWithText).
     fn curved_arrow<'a>(
-        relation: &'a semantic::Relation,
+        relation: &'a Relation,
         source: &Component<'_>,
         target: &Component<'_>,
         lane_offset: f32,
-    ) -> draw::PositionedArrowWithText<'a> {
+    ) -> PositionedArrowWithText<'a> {
         let Some((path, label_position)) = Self::lane_geometry(source, target, lane_offset) else {
             // Degenerate (zero-length centerline): fall back to straight.
             return StraightArrowPlacer::place_one(relation, source, target);
         };
 
         let arrow_def = Rc::clone(relation.arrow_definition());
-        let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
-        let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
+        let arrow = Arrow::new(arrow_def, relation.arrow_direction());
+        let arrow_with_text = ArrowWithText::new(arrow, relation.text());
 
-        draw::PositionedArrowWithText::new(arrow_with_text, path)
-            .with_text_position(Some(label_position))
+        PositionedArrowWithText::new(arrow_with_text, path).with_text_position(Some(label_position))
     }
 
     /// Computes the cubic-Bézier path and label position for a lane offset.
@@ -216,7 +212,7 @@ impl CurvedArrowPlacer {
         source: &Component<'_>,
         target: &Component<'_>,
         lane_offset: f32,
-    ) -> Option<(draw::ArrowPath, Point)> {
+    ) -> Option<(ArrowPath, Point)> {
         let src_center = source.position();
         let tgt_center = target.position();
 
@@ -239,19 +235,13 @@ impl CurvedArrowPlacer {
         let cp1 = third.add_point(perp);
         let cp2 = two_thirds.add_point(perp);
 
-        let path = draw::ArrowPath::new(src_edge, tgt_edge, vec![cp1, cp2]);
+        let path = ArrowPath::new(src_edge, tgt_edge, vec![cp1, cp2]);
         let label_position = cubic_bezier_midpoint(src_edge, cp1, cp2, tgt_edge);
         Some((path, label_position))
     }
 
     /// Lane offset for position `k` of `n`, sign-flipped for reverse relations.
-    fn lane_offset_at(
-        &self,
-        k: usize,
-        n: usize,
-        relation: &semantic::Relation,
-        source_id: Id,
-    ) -> f32 {
+    fn lane_offset_at(&self, k: usize, n: usize, relation: &Relation, source_id: Id) -> f32 {
         let offset = ((k as f32) - ((n - 1) as f32) / 2.0) * self.lane_spacing;
         if relation.source() != source_id {
             -offset
@@ -267,11 +257,7 @@ impl CurvedArrowPlacer {
     }
 
     /// Teardrop-shaped Bézier lobe path for a self-loop at `angle`.
-    fn self_loop_geometry(
-        &self,
-        component: &Component<'_>,
-        angle: f32,
-    ) -> (draw::ArrowPath, Point) {
+    fn self_loop_geometry(&self, component: &Component<'_>, angle: f32) -> (ArrowPath, Point) {
         let center = component.position();
         let direction = Point::new(angle.cos(), angle.sin());
         let component_size = component.bounds().to_size();
@@ -299,7 +285,7 @@ impl CurvedArrowPlacer {
         let cp1 = src_edge.add_point(outward);
         let cp2 = dst_edge.add_point(outward);
 
-        let path = draw::ArrowPath::new(src_edge, dst_edge, vec![cp1, cp2]);
+        let path = ArrowPath::new(src_edge, dst_edge, vec![cp1, cp2]);
         let label_position = cubic_bezier_midpoint(src_edge, cp1, cp2, dst_edge);
 
         (path, label_position)
@@ -308,18 +294,17 @@ impl CurvedArrowPlacer {
     /// Positioned self-loop arrow at the given outward `angle`.
     fn self_loop_arrow<'a>(
         &self,
-        relation: &'a semantic::Relation,
+        relation: &'a Relation,
         component: &Component<'_>,
         angle: f32,
-    ) -> draw::PositionedArrowWithText<'a> {
+    ) -> PositionedArrowWithText<'a> {
         let (path, label_position) = self.self_loop_geometry(component, angle);
 
         let arrow_def = Rc::clone(relation.arrow_definition());
-        let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
-        let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
+        let arrow = Arrow::new(arrow_def, relation.arrow_direction());
+        let arrow_with_text = ArrowWithText::new(arrow, relation.text());
 
-        draw::PositionedArrowWithText::new(arrow_with_text, path)
-            .with_text_position(Some(label_position))
+        PositionedArrowWithText::new(arrow_with_text, path).with_text_position(Some(label_position))
     }
 }
 
@@ -332,10 +317,10 @@ impl Default for CurvedArrowPlacer {
 impl ArrowPlacer for CurvedArrowPlacer {
     fn place<'a>(
         &self,
-        relations: &[&'a semantic::Relation],
+        relations: &[&'a Relation],
         source: &Component<'_>,
         target: &Component<'_>,
-    ) -> Vec<draw::PositionedArrowWithText<'a>> {
+    ) -> Vec<PositionedArrowWithText<'a>> {
         let n = relations.len();
         if source.node_id() == target.node_id() {
             relations
@@ -375,7 +360,7 @@ impl ArrowPlacer for CurvedArrowPlacer {
 #[derive(Debug, Clone)]
 pub struct Layout<'a> {
     components: Vec<Component<'a>>,
-    relations: Vec<draw::PositionedArrowWithText<'a>>,
+    relations: Vec<PositionedArrowWithText<'a>>,
     bounds: Bounds,
 }
 
@@ -383,7 +368,7 @@ impl<'a> Layout<'a> {
     /// Creates a new layout with the given components and relations.
     pub fn new(
         components: Vec<Component<'a>>,
-        relations: Vec<draw::PositionedArrowWithText<'a>>,
+        relations: Vec<PositionedArrowWithText<'a>>,
     ) -> Self {
         let bounds = if components.is_empty() {
             Bounds::default()
@@ -409,7 +394,7 @@ impl<'a> Layout<'a> {
     }
 
     /// Returns a reference to the relations in this layout.
-    pub fn relations(&self) -> &[draw::PositionedArrowWithText<'a>] {
+    pub fn relations(&self) -> &[PositionedArrowWithText<'a>] {
         &self.relations
     }
 }
@@ -440,8 +425,8 @@ impl<'a> LayoutBounds for Layout<'a> {
 /// is not found in its corresponding layout layer.
 // TODO: Once added enough abstractions, make this a method on ContentStack.
 pub fn adjust_positioned_contents_offset<'a>(
-    content_stack: &mut layer::ContentStack<Layout>,
-    graph: &'a structure::ComponentGraph<'a, '_>,
+    content_stack: &mut ContentStack<Layout>,
+    graph: &'a ComponentGraph<'a, '_>,
 ) -> Result<(), RenderError> {
     let container_indices: HashMap<_, _> = graph
         .containment_scopes()
@@ -508,7 +493,7 @@ pub fn adjust_positioned_contents_offset<'a>(
 /// Returns `(source, target)` or `(target, source)` depending on which
 /// component matches `relation.source()`.
 fn align_to_relation<'a, 'b>(
-    relation: &semantic::Relation,
+    relation: &Relation,
     source: &'b Component<'a>,
     target: &'b Component<'a>,
 ) -> (&'b Component<'a>, &'b Component<'a>) {
@@ -541,6 +526,11 @@ mod tests {
 
     use float_cmp::{approx_eq, assert_approx_eq};
 
+    use orrery_core::{
+        draw::{ArrowDefinition, ArrowDirection, RectangleDefinition, Shape, ShapeDefinition},
+        semantic::Block,
+    };
+
     use super::*;
 
     fn assert_point_approx_eq(actual: Point, expected: Point) {
@@ -555,26 +545,25 @@ mod tests {
         );
     }
 
-    fn make_relation(source: Id, target: Id) -> semantic::Relation {
-        semantic::Relation::new(
+    fn make_relation(source: Id, target: Id) -> Relation {
+        Relation::new(
             source,
             target,
-            draw::ArrowDirection::Forward,
+            ArrowDirection::Forward,
             None,
-            Rc::new(draw::ArrowDefinition::default()),
+            Rc::new(ArrowDefinition::default()),
         )
     }
 
-    fn make_node(name: &str) -> semantic::Node {
+    fn make_node(name: &str) -> Node {
         let id = Id::new(name);
-        let shape_def =
-            Rc::new(Box::new(draw::RectangleDefinition::new()) as Box<dyn draw::ShapeDefinition>);
-        semantic::Node::new(id, None, semantic::Block::None, shape_def)
+        let shape_def = Rc::new(Box::new(RectangleDefinition::new()) as Box<dyn ShapeDefinition>);
+        Node::new(id, None, Block::None, shape_def)
     }
 
-    fn make_component<'a>(node: &'a semantic::Node, position: Point) -> Component<'a> {
-        let shape = draw::Shape::new(Rc::clone(node.shape_definition()));
-        let shape_with_text = draw::ShapeWithText::new(shape, None);
+    fn make_component<'a>(node: &'a Node, position: Point) -> Component<'a> {
+        let shape = Shape::new(Rc::clone(node.shape_definition()));
+        let shape_with_text = ShapeWithText::new(shape, None);
         Component::new(node, shape_with_text, position)
     }
 

--- a/crates/orrery/src/layout/engines.rs
+++ b/crates/orrery/src/layout/engines.rs
@@ -18,17 +18,21 @@ use std::collections::HashMap;
 
 use log::trace;
 
-use orrery_core::{geometry, identifier::Id, semantic::LayoutEngine};
+use orrery_core::{
+    geometry::{Insets, Size},
+    identifier::Id,
+    semantic::LayoutEngine,
+};
 
 use super::layer::ContentStack;
 use crate::{
     error::RenderError,
     layout::{
-        component,
+        component::Layout as ComponentLayout,
         layer::{LayeredLayout, LayoutContent},
-        sequence,
+        sequence::Layout as SequenceLayout,
     },
-    structure,
+    structure::{ComponentGraph, DiagramHierarchy, GraphKind, SequenceGraph},
 };
 
 /// Enum to store different layout results based on diagram type.
@@ -37,13 +41,13 @@ use crate::{
 #[derive(Debug, Clone)]
 pub enum LayoutResult<'a> {
     // TODO: Do I need this?
-    Component(ContentStack<component::Layout<'a>>),
-    Sequence(ContentStack<sequence::Layout<'a>>),
+    Component(ContentStack<ComponentLayout<'a>>),
+    Sequence(ContentStack<SequenceLayout<'a>>),
 }
 
 impl<'a> LayoutResult<'a> {
     /// Calculate the size of this layout, using the appropriate sizing implementation
-    fn calculate_size(&self) -> geometry::Size {
+    fn calculate_size(&self) -> Size {
         match self {
             LayoutResult::Component(layout) => layout.layout_size(),
             LayoutResult::Sequence(layout) => layout.layout_size(),
@@ -75,9 +79,9 @@ pub trait ComponentEngine {
     /// Returns [`RenderError::Layout`] if the layout engine fails to calculate positions.
     fn calculate<'a>(
         &self,
-        graph: &'a structure::ComponentGraph<'a, '_>,
+        graph: &'a ComponentGraph<'a, '_>,
         embedded_layouts: &EmbeddedLayouts<'a>,
-    ) -> Result<ContentStack<component::Layout<'a>>, RenderError>;
+    ) -> Result<ContentStack<ComponentLayout<'a>>, RenderError>;
 }
 
 /// Layout engine for sequence diagrams.
@@ -100,9 +104,9 @@ pub trait SequenceEngine {
     /// Returns [`RenderError::Layout`] if the layout engine fails to calculate positions.
     fn calculate<'a>(
         &self,
-        graph: &'a structure::SequenceGraph<'a>,
+        graph: &'a SequenceGraph<'a>,
         embedded_layouts: &EmbeddedLayouts<'a>,
-    ) -> Result<ContentStack<sequence::Layout<'a>>, RenderError>;
+    ) -> Result<ContentStack<SequenceLayout<'a>>, RenderError>;
 }
 
 /// Builder for creating and configuring layout engines.
@@ -115,7 +119,7 @@ pub struct EngineBuilder {
     sequence_engines: HashMap<LayoutEngine, Box<dyn SequenceEngine>>,
 
     // Configuration options
-    padding: geometry::Insets,
+    padding: Insets,
     min_spacing: f32,
     horizontal_spacing: f32,
     vertical_spacing: f32,
@@ -129,7 +133,7 @@ impl EngineBuilder {
     }
 
     /// Set the padding inside all shapes (components, participants, containers).
-    pub fn with_padding(mut self, padding: geometry::Insets) -> Self {
+    pub fn with_padding(mut self, padding: Insets) -> Self {
         self.padding = padding;
         self
     }
@@ -219,7 +223,7 @@ impl EngineBuilder {
     /// Returns `RenderError::Layout` if any layout engine fails to calculate positions.
     pub fn build<'a>(
         mut self,
-        collection: &'a structure::DiagramHierarchy<'a, '_>,
+        collection: &'a DiagramHierarchy<'a, '_>,
     ) -> Result<LayeredLayout<'a>, RenderError> {
         let mut layered_layout = LayeredLayout::new();
 
@@ -241,13 +245,13 @@ impl EngineBuilder {
             // Calculate the layout for this diagram using the appropriate engine
             let diagram = graphed_diagram.ast_diagram();
             let layout_result = match graphed_diagram.graph_kind() {
-                structure::GraphKind::ComponentGraph(graph) => {
+                GraphKind::ComponentGraph(graph) => {
                     let engine = self.component_engine(diagram.layout_engine());
 
                     let layout = engine.calculate(graph, &layout_info)?;
                     LayoutResult::Component(layout)
                 }
-                structure::GraphKind::SequenceGraph(graph) => {
+                GraphKind::SequenceGraph(graph) => {
                     let engine = self.sequence_engine(diagram.layout_engine());
 
                     let layout = engine.calculate(graph, &layout_info)?;

--- a/crates/orrery/src/layout/engines/basic/component.rs
+++ b/crates/orrery/src/layout/engines/basic/component.rs
@@ -9,18 +9,16 @@ use std::{
 };
 
 use orrery_core::{
-    draw::{self, Drawable},
+    draw::{Drawable, PositionedArrowWithText, Shape, ShapeWithText, Text},
     geometry::{Insets, Point, Size},
     identifier::Id,
-    semantic,
+    semantic::{Block, Relation},
 };
 
 use crate::{
     error::RenderError,
     layout::{
-        component::{
-            ArrowPlacer, Component, CurvedArrowPlacer, Layout, adjust_positioned_contents_offset,
-        },
+        component::{self, ArrowPlacer, Component, CurvedArrowPlacer, Layout},
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -145,7 +143,7 @@ impl Engine {
             content_stack.push(positioned_content);
         }
 
-        adjust_positioned_contents_offset(&mut content_stack, graph)?;
+        component::adjust_positioned_contents_offset(&mut content_stack, graph)?;
 
         Ok(content_stack)
     }
@@ -161,8 +159,8 @@ impl Engine {
         containment_scope: &ContainmentScope,
         components: &[Component<'a>],
         component_indices: &HashMap<Id, usize>,
-    ) -> Vec<draw::PositionedArrowWithText<'a>> {
-        let mut buckets: HashMap<(Id, Id), Vec<&'a semantic::Relation>> = HashMap::new();
+    ) -> Vec<PositionedArrowWithText<'a>> {
+        let mut buckets: HashMap<(Id, Id), Vec<&'a Relation>> = HashMap::new();
 
         for relation in graph.scope_relations(containment_scope) {
             let source_id = relation.source();
@@ -200,18 +198,18 @@ impl Engine {
         containment_scope: &ContainmentScope,
         positioned_content_sizes: &HashMap<Id, Size>,
         embedded_layouts: &EmbeddedLayouts<'a>,
-    ) -> Result<HashMap<Id, draw::ShapeWithText<'a>>, RenderError> {
-        let mut component_shapes: HashMap<Id, draw::ShapeWithText<'a>> = HashMap::new();
+    ) -> Result<HashMap<Id, ShapeWithText<'a>>, RenderError> {
+        let mut component_shapes: HashMap<Id, ShapeWithText<'a>> = HashMap::new();
 
         // TODO: move it to the best place.
         for node in graph.scope_nodes(containment_scope) {
-            let mut shape = draw::Shape::new(Rc::clone(node.shape_definition()));
+            let mut shape = Shape::new(Rc::clone(node.shape_definition()));
             shape.set_padding(self.padding);
-            let text = draw::Text::new(node.shape_definition().text(), node.display_text());
-            let mut shape_with_text = draw::ShapeWithText::new(shape, Some(text));
+            let text = Text::new(node.shape_definition().text(), node.display_text());
+            let mut shape_with_text = ShapeWithText::new(shape, Some(text));
 
             match node.block() {
-                semantic::Block::Diagram(_) => {
+                Block::Diagram(_) => {
                     // Since we process in post-order (innermost to outermost),
                     // embedded diagram layouts should already be calculated and available
                     let layout = embedded_layouts.get(&node.id()).ok_or_else(|| {
@@ -229,7 +227,7 @@ impl Engine {
                             ))
                         })?;
                 }
-                semantic::Block::Scope(_) => {
+                Block::Scope(_) => {
                     let content_size =
                         *positioned_content_sizes.get(&node.id()).ok_or_else(|| {
                             RenderError::Layout(format!("Scope size not found for node '{node}'"))
@@ -242,7 +240,7 @@ impl Engine {
                             ))
                         })?;
                 }
-                semantic::Block::None => {
+                Block::None => {
                     // No content to size, so don't call set_inner_content_size
                 }
             };
@@ -257,7 +255,7 @@ impl Engine {
         &self,
         graph: &'a ComponentGraph<'a, '_>,
         containment_scope: &ContainmentScope,
-        component_shapes: &HashMap<Id, draw::ShapeWithText<'a>>,
+        component_shapes: &HashMap<Id, ShapeWithText<'a>>,
     ) -> Result<HashMap<Id, Point>, RenderError> {
         // Step 1: Assign layers for the top-level nodes
         let layers = Self::assign_layers_for_containment_scope_graph(graph, containment_scope)?;
@@ -276,7 +274,7 @@ impl Engine {
         graph: &'a ComponentGraph<'a, '_>,
         containment_scope: &ContainmentScope,
         layers: &[Vec<Id>],
-        component_shapes: &HashMap<Id, draw::ShapeWithText<'a>>,
+        component_shapes: &HashMap<Id, ShapeWithText<'a>>,
     ) -> Result<(Vec<f32>, Vec<f32>), RenderError> {
         // Calculate max width for each layer
         let layer_widths: Vec<f32> = layers
@@ -331,7 +329,7 @@ impl Engine {
     // PERF: Deprecate this method in favor of a more efficient approach.
     fn find_node_layers(
         &self,
-        relation: &semantic::Relation,
+        relation: &Relation,
         layers: &[Vec<Id>],
     ) -> (Option<usize>, Option<usize>) {
         let mut source_layer = None;
@@ -378,7 +376,7 @@ impl Engine {
         &self,
         layers: &[Vec<Id>],
         layer_x_positions: &[f32],
-        component_shapes: &HashMap<Id, draw::ShapeWithText<'a>>,
+        component_shapes: &HashMap<Id, ShapeWithText<'a>>,
     ) -> Result<HashMap<Id, Point>, RenderError> {
         let mut positions = HashMap::new();
 

--- a/crates/orrery/src/layout/engines/basic/sequence.rs
+++ b/crates/orrery/src/layout/engines/basic/sequence.rs
@@ -6,10 +6,14 @@
 use std::{cmp::Ordering, collections::HashMap, rc::Rc};
 
 use orrery_core::{
-    draw::{self, Drawable as _},
+    draw::{
+        Arrow, ArrowPath, ArrowStyle, ArrowWithText, Drawable, Fragment, Lifeline,
+        LifelineDefinition, Note as DrawNote, PositionedArrowWithText, PositionedDrawable, Shape,
+        ShapeWithText, Text,
+    },
     geometry::{Insets, Point, Size},
     identifier::Id,
-    semantic,
+    semantic::{Block, Note, NoteAlign, Relation},
 };
 
 use crate::{
@@ -35,7 +39,7 @@ struct Message<'a> {
     source: Id,
     target: Id,
     y_position: f32,
-    arrow_with_text: draw::ArrowWithText<'a>,
+    arrow_with_text: ArrowWithText<'a>,
 }
 
 impl<'a> Message<'a> {
@@ -54,13 +58,13 @@ impl<'a> Message<'a> {
     ///
     /// A [`Message`] with `y_position` defaulted to `0.0`; callers should
     /// finalize the position with [`Self::set_y_position`].
-    fn from_relation(relation: &'a semantic::Relation, source: Id, target: Id) -> Self {
+    fn from_relation(relation: &'a Relation, source: Id, target: Id) -> Self {
         let mut arrow_def = Rc::clone(relation.arrow_definition());
-        if source == target && *arrow_def.style() != draw::ArrowStyle::Curved {
-            Rc::make_mut(&mut arrow_def).set_style(draw::ArrowStyle::Curved);
+        if source == target && *arrow_def.style() != ArrowStyle::Curved {
+            Rc::make_mut(&mut arrow_def).set_style(ArrowStyle::Curved);
         }
-        let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
-        let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
+        let arrow = Arrow::new(arrow_def, relation.arrow_direction());
+        let arrow_with_text = ArrowWithText::new(arrow, relation.text());
         Self {
             source,
             target,
@@ -100,7 +104,7 @@ impl<'a> Message<'a> {
     }
 
     /// Consumes self and returns the inner [`ArrowWithText`](draw::ArrowWithText).
-    fn into_arrow_with_text(self) -> draw::ArrowWithText<'a> {
+    fn into_arrow_with_text(self) -> ArrowWithText<'a> {
         self.arrow_with_text
     }
 }
@@ -110,8 +114,8 @@ impl<'a> Message<'a> {
 type ProcessEventsResult<'a> = (
     Vec<Message<'a>>,
     Vec<ActivationBox>,
-    Vec<draw::PositionedDrawable<draw::Fragment>>,
-    Vec<draw::PositionedDrawable<draw::Note>>,
+    Vec<PositionedDrawable<Fragment>>,
+    Vec<PositionedDrawable<DrawNote>>,
     f32,
 );
 
@@ -267,12 +271,12 @@ impl Engine {
         // Create shapes with text for participants
         let mut participant_shapes: HashMap<_, _> = HashMap::new();
         for node in graph.nodes() {
-            let mut shape = draw::Shape::new(Rc::clone(node.shape_definition()));
+            let mut shape = Shape::new(Rc::clone(node.shape_definition()));
             shape.set_padding(self.padding);
-            let text = draw::Text::new(node.shape_definition().text(), node.display_text());
-            let mut shape_with_text = draw::ShapeWithText::new(shape, Some(text));
+            let text = Text::new(node.shape_definition().text(), node.display_text());
+            let mut shape_with_text = ShapeWithText::new(shape, Some(text));
 
-            if let semantic::Block::Diagram(_) = node.block() {
+            if let Block::Diagram(_) = node.block() {
                 // If this participant has an embedded diagram, use its layout size
                 let content_size = if let Some(layout) = embedded_layouts.get(&node.id()) {
                     layout.calculate_size()
@@ -363,8 +367,8 @@ impl Engine {
                 let position = component.position();
                 let lifeline_start_y = component.bounds().max_y();
                 let height = (lifeline_end - lifeline_start_y).max(0.0);
-                let lifeline = draw::PositionedDrawable::new(draw::Lifeline::new(
-                    Rc::new(draw::LifelineDefinition::default()),
+                let lifeline = PositionedDrawable::new(Lifeline::new(
+                    Rc::new(LifelineDefinition::default()),
                     height,
                 ))
                 .with_position(Point::new(position.x(), lifeline_start_y));
@@ -406,7 +410,7 @@ impl Engine {
         &self,
         source_id: Id,
         target_id: Id,
-        messages: &[&semantic::Relation],
+        messages: &[&Relation],
     ) -> f32 {
         let relevant_messages = messages
             .iter()
@@ -416,9 +420,7 @@ impl Engine {
                     || (relation.source() == target_id && relation.target() == source_id)
             })
             .copied();
-        let has_self_loop = relevant_messages
-            .clone()
-            .any(semantic::Relation::is_self_loop);
+        let has_self_loop = relevant_messages.clone().any(Relation::is_self_loop);
         let mut max_size = relevant_messages
             .flat_map(|relation| relation.text().map(|t| t.calculate_size()))
             .fold(Size::zero(), Size::max);
@@ -442,17 +444,17 @@ impl Engine {
         messages: Vec<Message<'a>>,
         activations: &[ActivationBox],
         components: &HashMap<Id, Component<'a>>,
-    ) -> Vec<draw::PositionedArrowWithText<'a>> {
+    ) -> Vec<PositionedArrowWithText<'a>> {
         messages
             .into_iter()
             .map(|msg| {
                 if msg.is_self_loop() {
                     let (path, label_position) = self.self_loop_path(&msg, activations, components);
-                    draw::PositionedArrowWithText::new(msg.into_arrow_with_text(), path)
+                    PositionedArrowWithText::new(msg.into_arrow_with_text(), path)
                         .with_text_position(label_position)
                 } else {
                     let path = Self::cross_participant_path(&msg, activations, components);
-                    draw::PositionedArrowWithText::new(msg.into_arrow_with_text(), path)
+                    PositionedArrowWithText::new(msg.into_arrow_with_text(), path)
                 }
             })
             .collect()
@@ -476,7 +478,7 @@ impl Engine {
         msg: &Message<'_>,
         activations: &[ActivationBox],
         components: &HashMap<Id, Component<'_>>,
-    ) -> draw::ArrowPath {
+    ) -> ArrowPath {
         let source_participant = &components[&msg.source()];
         let target_participant = &components[&msg.target()];
 
@@ -497,7 +499,7 @@ impl Engine {
 
         let start_point = Point::new(source_x, msg.y_position());
         let end_point = Point::new(target_x, msg.y_position());
-        draw::ArrowPath::straight(start_point, end_point)
+        ArrowPath::straight(start_point, end_point)
     }
 
     /// Computes a rounded-rectangular [`draw::ArrowPath`] for a self-loop on a
@@ -540,7 +542,7 @@ impl Engine {
         msg: &Message<'_>,
         activations: &[ActivationBox],
         components: &HashMap<Id, Component<'_>>,
-    ) -> (draw::ArrowPath, Option<Point>) {
+    ) -> (ArrowPath, Option<Point>) {
         debug_assert!(msg.is_self_loop(), "expected self-loop message");
 
         // Geometry:
@@ -616,7 +618,7 @@ impl Engine {
             s5_cp2,
         ];
 
-        let path = draw::ArrowPath::new(a0, a5, control_points);
+        let path = ArrowPath::new(a0, a5, control_points);
 
         let label_position = if content_size.is_zero() {
             None
@@ -669,8 +671,8 @@ impl Engine {
     ) -> Result<ProcessEventsResult<'a>, RenderError> {
         let mut messages: Vec<Message<'a>> = Vec::new();
         let mut activation_boxes: Vec<ActivationBox> = Vec::new();
-        let mut fragments: Vec<draw::PositionedDrawable<draw::Fragment>> = Vec::new();
-        let mut notes: Vec<draw::PositionedDrawable<draw::Note>> = Vec::new();
+        let mut fragments: Vec<PositionedDrawable<Fragment>> = Vec::new();
+        let mut notes: Vec<PositionedDrawable<DrawNote>> = Vec::new();
 
         let mut activation_stack: HashMap<Id, Vec<ActivationTiming>> = HashMap::new();
         let mut fragment_stack: Vec<FragmentTiming> = Vec::new();
@@ -845,10 +847,10 @@ impl Engine {
     /// A `PositionedDrawable<Note>` ready to be added to the layout
     fn create_positioned_note<'a>(
         &self,
-        note: &semantic::Note,
+        note: &Note,
         components: &HashMap<Id, Component<'a>>,
         current_y: f32,
-    ) -> Result<draw::PositionedDrawable<draw::Note>, RenderError> {
+    ) -> Result<PositionedDrawable<DrawNote>, RenderError> {
         const NOTE_SPACING: f32 = 20.0; // Spacing between note and participant lifeline
 
         // Select appropriate components: all if on=[], otherwise specified ones
@@ -866,17 +868,17 @@ impl Engine {
         };
 
         let edge_map: fn(&Component) -> (f32, f32) = match note.align() {
-            semantic::NoteAlign::Over => |component| {
+            NoteAlign::Over => |component| {
                 let center_x = component.position().x();
                 let width = component.drawable().size().width();
                 let left_edge = center_x - width / 2.0;
                 let right_edge = center_x + width / 2.0;
                 (left_edge, right_edge)
             },
-            semantic::NoteAlign::Left | semantic::NoteAlign::Right => {
+            NoteAlign::Left | NoteAlign::Right => {
                 |component| (component.position().x(), component.position().x())
             }
-            semantic::NoteAlign::Top | semantic::NoteAlign::Bottom => {
+            NoteAlign::Top | NoteAlign::Bottom => {
                 unreachable!("Alignments is not supported for sequence diagrams")
             }
         };
@@ -890,25 +892,25 @@ impl Engine {
             })?;
 
         let mut new_note_def = Rc::clone(note.definition());
-        if note.align() == semantic::NoteAlign::Over {
+        if note.align() == NoteAlign::Over {
             let note_def_mut = Rc::make_mut(&mut new_note_def);
             note_def_mut.set_min_width(Some(max_x - min_x));
         }
 
-        let note_drawable = draw::Note::new(new_note_def, note.content().to_string());
+        let note_drawable = DrawNote::new(new_note_def, note.content().to_string());
 
         let note_size = note_drawable.size();
         let center_x = match note.align() {
-            semantic::NoteAlign::Over => (min_x + max_x) / 2.0,
-            semantic::NoteAlign::Left => min_x - (note_size.width() / 2.0) - NOTE_SPACING,
-            semantic::NoteAlign::Right => max_x + (note_size.width() / 2.0) + NOTE_SPACING,
-            semantic::NoteAlign::Top | semantic::NoteAlign::Bottom => {
+            NoteAlign::Over => (min_x + max_x) / 2.0,
+            NoteAlign::Left => min_x - (note_size.width() / 2.0) - NOTE_SPACING,
+            NoteAlign::Right => max_x + (note_size.width() / 2.0) + NOTE_SPACING,
+            NoteAlign::Top | NoteAlign::Bottom => {
                 unreachable!("Alignments is not supported for sequence diagrams")
             }
         };
         let position = Point::new(center_x, current_y + note_size.height() / 2.0);
 
-        Ok(draw::PositionedDrawable::new(note_drawable).with_position(position))
+        Ok(PositionedDrawable::new(note_drawable).with_position(position))
     }
 }
 
@@ -941,12 +943,15 @@ fn line_segment_cubic_cps(start: Point, end: Point) -> (Point, Point) {
 mod tests {
     use super::*;
 
-    use orrery_core::draw::{ArrowDefinition, ArrowDirection, ArrowStyle, RectangleDefinition};
+    use orrery_core::{
+        draw::{ActivationBoxDefinition, ArrowDefinition, ArrowDirection, RectangleDefinition},
+        semantic::Node,
+    };
 
-    fn make_relation(source: Id, target: Id, label: Option<&str>) -> semantic::Relation {
+    fn make_relation(source: Id, target: Id, label: Option<&str>) -> Relation {
         let mut def = ArrowDefinition::default();
         def.set_style(ArrowStyle::Straight);
-        semantic::Relation::new(
+        Relation::new(
             source,
             target,
             ArrowDirection::Forward,
@@ -955,17 +960,17 @@ mod tests {
         )
     }
 
-    fn make_node(name: &str) -> semantic::Node {
+    fn make_node(name: &str) -> Node {
         let id = Id::new(name);
         let shape_def = Rc::new(
             Box::new(RectangleDefinition::new()) as Box<dyn orrery_core::draw::ShapeDefinition>
         );
-        semantic::Node::new(id, None, semantic::Block::None, shape_def)
+        Node::new(id, None, Block::None, shape_def)
     }
 
-    fn make_component<'a>(node: &'a semantic::Node, position: Point) -> Component<'a> {
-        let shape = draw::Shape::new(Rc::clone(node.shape_definition()));
-        let shape_with_text = draw::ShapeWithText::new(shape, None);
+    fn make_component<'a>(node: &'a Node, position: Point) -> Component<'a> {
+        let shape = Shape::new(Rc::clone(node.shape_definition()));
+        let shape_with_text = ShapeWithText::new(shape, None);
         Component::new(node, shape_with_text, position)
     }
 
@@ -1074,12 +1079,8 @@ mod tests {
         components.insert(id, component);
 
         // Default activation-box width = 8 → right edge sits at participant_x + 4.
-        let timing = ActivationTiming::new(
-            id,
-            180.0,
-            0,
-            Rc::new(draw::ActivationBoxDefinition::default()),
-        );
+        let timing =
+            ActivationTiming::new(id, 180.0, 0, Rc::new(ActivationBoxDefinition::default()));
         let activations = vec![timing.to_activation_box(220.0)];
 
         let relation = make_relation(id, id, None);

--- a/crates/orrery/src/layout/engines/graphviz/component.rs
+++ b/crates/orrery/src/layout/engines/graphviz/component.rs
@@ -8,16 +8,16 @@
 use std::{collections::HashMap, rc::Rc};
 
 use orrery_core::{
-    draw::{self, Drawable},
+    draw::{Arrow, ArrowWithText, Drawable, PositionedArrowWithText, Shape, ShapeWithText, Text},
     geometry::{Insets, Size},
     identifier::Id,
-    semantic,
+    semantic::Block,
 };
 
 use crate::{
     error::RenderError,
     layout::{
-        component::{Component, Layout, adjust_positioned_contents_offset},
+        component::{self, Component, Layout},
         engines::{ComponentEngine, EmbeddedLayouts, graphviz::dot_bridge::DotBridge},
         layer::{ContentStack, PositionedContent},
     },
@@ -100,7 +100,7 @@ impl Engine {
             content_stack.push(positioned_content);
         }
 
-        adjust_positioned_contents_offset(&mut content_stack, graph)?;
+        component::adjust_positioned_contents_offset(&mut content_stack, graph)?;
 
         Ok(content_stack)
     }
@@ -172,14 +172,14 @@ impl Engine {
             .collect::<Result<_, RenderError>>()?;
 
         // Build relations from the Graphviz edge paths
-        let relations: Vec<draw::PositionedArrowWithText> = layout_result
+        let relations: Vec<PositionedArrowWithText> = layout_result
             .into_edge_paths()
             .into_iter()
             .map(|(relation, path)| {
                 let arrow_def = Rc::clone(relation.arrow_definition());
-                let arrow = draw::Arrow::new(arrow_def, relation.arrow_direction());
-                let arrow_with_text = draw::ArrowWithText::new(arrow, relation.text());
-                draw::PositionedArrowWithText::new(arrow_with_text, path)
+                let arrow = Arrow::new(arrow_def, relation.arrow_direction());
+                let arrow_with_text = ArrowWithText::new(arrow, relation.text());
+                PositionedArrowWithText::new(arrow_with_text, path)
             })
             .collect();
 
@@ -196,17 +196,17 @@ impl Engine {
         containment_scope: &ContainmentScope,
         positioned_content_sizes: &HashMap<Id, Size>,
         embedded_layouts: &EmbeddedLayouts<'a>,
-    ) -> Result<HashMap<Id, draw::ShapeWithText<'a>>, RenderError> {
-        let mut component_shapes: HashMap<Id, draw::ShapeWithText<'a>> = HashMap::new();
+    ) -> Result<HashMap<Id, ShapeWithText<'a>>, RenderError> {
+        let mut component_shapes: HashMap<Id, ShapeWithText<'a>> = HashMap::new();
 
         for node in graph.scope_nodes(containment_scope) {
-            let mut shape = draw::Shape::new(Rc::clone(node.shape_definition()));
+            let mut shape = Shape::new(Rc::clone(node.shape_definition()));
             shape.set_padding(self.container_padding);
-            let text = draw::Text::new(node.shape_definition().text(), node.display_text());
-            let mut shape_with_text = draw::ShapeWithText::new(shape, Some(text));
+            let text = Text::new(node.shape_definition().text(), node.display_text());
+            let mut shape_with_text = ShapeWithText::new(shape, Some(text));
 
             match node.block() {
-                semantic::Block::Diagram(_) => {
+                Block::Diagram(_) => {
                     // Since we process in post-order (innermost to outermost),
                     // embedded diagram layouts should already be calculated and available
                     let layout = embedded_layouts.get(&node.id()).ok_or_else(|| {
@@ -222,7 +222,7 @@ impl Engine {
                             ))
                         })?;
                 }
-                semantic::Block::Scope(_) => {
+                Block::Scope(_) => {
                     let content_size =
                         *positioned_content_sizes.get(&node.id()).ok_or_else(|| {
                             RenderError::Layout(format!("scope size not found for `{node}`"))
@@ -235,7 +235,7 @@ impl Engine {
                             ))
                         })?;
                 }
-                semantic::Block::None => {
+                Block::None => {
                     // No content to size, so don't call set_inner_content_size
                 }
             };

--- a/crates/orrery/src/layout/engines/sugiyama/component.rs
+++ b/crates/orrery/src/layout/engines/sugiyama/component.rs
@@ -6,18 +6,16 @@ use log::debug;
 use rust_sugiyama::configure::Config;
 
 use orrery_core::{
-    draw::{self, Drawable},
+    draw::{Drawable, PositionedArrowWithText, Shape, ShapeWithText, Text},
     geometry::{Insets, Point, Size},
     identifier::Id,
-    semantic,
+    semantic::{Block, Relation},
 };
 
 use crate::{
     error::RenderError,
     layout::{
-        component::{
-            ArrowPlacer, Component, CurvedArrowPlacer, Layout, adjust_positioned_contents_offset,
-        },
+        component::{self, ArrowPlacer, Component, CurvedArrowPlacer, Layout},
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -140,7 +138,7 @@ impl Engine {
             content_stack.push(positioned_content);
         }
 
-        adjust_positioned_contents_offset(&mut content_stack, graph)?;
+        component::adjust_positioned_contents_offset(&mut content_stack, graph)?;
 
         Ok(content_stack)
     }
@@ -156,8 +154,8 @@ impl Engine {
         containment_scope: &ContainmentScope,
         components: &[Component<'a>],
         component_indices: &HashMap<Id, usize>,
-    ) -> Vec<draw::PositionedArrowWithText<'a>> {
-        let mut buckets: HashMap<(Id, Id), Vec<&'a semantic::Relation>> = HashMap::new();
+    ) -> Vec<PositionedArrowWithText<'a>> {
+        let mut buckets: HashMap<(Id, Id), Vec<&'a Relation>> = HashMap::new();
 
         for relation in graph.scope_relations(containment_scope) {
             let source_id = relation.source();
@@ -195,18 +193,18 @@ impl Engine {
         containment_scope: &ContainmentScope,
         positioned_content_sizes: &HashMap<Id, Size>,
         embedded_layouts: &EmbeddedLayouts<'a>,
-    ) -> Result<HashMap<Id, draw::ShapeWithText<'a>>, RenderError> {
-        let mut component_shapes: HashMap<Id, draw::ShapeWithText<'a>> = HashMap::new();
+    ) -> Result<HashMap<Id, ShapeWithText<'a>>, RenderError> {
+        let mut component_shapes: HashMap<Id, ShapeWithText<'a>> = HashMap::new();
 
         // TODO: move it to the best place.
         for node in graph.scope_nodes(containment_scope) {
-            let mut shape = draw::Shape::new(Rc::clone(node.shape_definition()));
+            let mut shape = Shape::new(Rc::clone(node.shape_definition()));
             shape.set_padding(self.container_padding);
-            let text = draw::Text::new(node.shape_definition().text(), node.display_text());
-            let mut shape_with_text = draw::ShapeWithText::new(shape, Some(text));
+            let text = Text::new(node.shape_definition().text(), node.display_text());
+            let mut shape_with_text = ShapeWithText::new(shape, Some(text));
 
             match node.block() {
-                semantic::Block::Diagram(_) => {
+                Block::Diagram(_) => {
                     // Since we process in post-order (innermost to outermost),
                     // embedded diagram layouts should already be calculated and available
                     let layout = embedded_layouts.get(&node.id()).ok_or_else(|| {
@@ -222,7 +220,7 @@ impl Engine {
                             ))
                         })?;
                 }
-                semantic::Block::Scope(_) => {
+                Block::Scope(_) => {
                     let content_size =
                         *positioned_content_sizes.get(&node.id()).ok_or_else(|| {
                             RenderError::Layout(format!("Scope size not found for node {node}"))
@@ -235,7 +233,7 @@ impl Engine {
                             ))
                         })?;
                 }
-                semantic::Block::None => {
+                Block::None => {
                     // No content to size, so don't call set_inner_content_size
                 }
             };

--- a/crates/orrery/src/layout/layer.rs
+++ b/crates/orrery/src/layout/layer.rs
@@ -15,20 +15,23 @@
 use log::debug;
 
 use orrery_core::{
-    draw,
+    draw::{PositionedDrawable, ShapeWithText},
     geometry::{Bounds, Point, Size},
 };
 
 use crate::{
     error::RenderError,
-    layout::{component, positioning::LayoutBounds, sequence},
+    layout::{
+        component::Layout as ComponentLayout, positioning::LayoutBounds,
+        sequence::Layout as SequenceLayout,
+    },
 };
 
 /// Content types that can be laid out in a layer
 #[derive(Debug)]
 pub enum LayoutContent<'a> {
-    Component(ContentStack<component::Layout<'a>>),
-    Sequence(ContentStack<sequence::Layout<'a>>),
+    Component(ContentStack<ComponentLayout<'a>>),
+    Sequence(ContentStack<SequenceLayout<'a>>),
 }
 
 /// A rendering layer containing either component or sequence diagram content
@@ -125,7 +128,7 @@ impl<'a> LayeredLayout<'a> {
     pub fn adjust_relative_position(
         &mut self,
         container_idx: usize,
-        positioned_shape: &draw::PositionedDrawable<draw::ShapeWithText>,
+        positioned_shape: &PositionedDrawable<ShapeWithText>,
         embedded_idx: usize,
     ) -> Result<(), RenderError> {
         let [container_layer, embedded_layer] =

--- a/crates/orrery/src/layout/sequence.rs
+++ b/crates/orrery/src/layout/sequence.rs
@@ -8,27 +8,28 @@ use std::{collections::HashMap, rc::Rc};
 use log::warn;
 
 use orrery_core::{
-    draw,
+    draw::{
+        ActivationBox as DrawActivationBox, ActivationBoxDefinition, Fragment as DrawFragment,
+        FragmentSection as DrawFragmentSection, Lifeline, Note, PositionedArrowWithText,
+        PositionedDrawable,
+    },
     geometry::{Bounds, Point, Size},
     identifier::Id,
-    semantic,
+    semantic::{Fragment, FragmentSection},
 };
 
-use crate::layout::{component, positioning::LayoutBounds};
+use crate::layout::{component::Component, positioning::LayoutBounds};
 
 /// Sequence diagram participant that holds its drawable component and lifeline.
 #[derive(Debug, Clone)]
 pub struct Participant<'a> {
-    component: component::Component<'a>,
-    lifeline: draw::PositionedDrawable<draw::Lifeline>,
+    component: Component<'a>,
+    lifeline: PositionedDrawable<Lifeline>,
 }
 
 impl<'a> Participant<'a> {
     /// Create a participant from its component and lifeline.
-    pub fn new(
-        component: component::Component<'a>,
-        lifeline: draw::PositionedDrawable<draw::Lifeline>,
-    ) -> Self {
+    pub fn new(component: Component<'a>, lifeline: PositionedDrawable<Lifeline>) -> Self {
         Self {
             component,
             lifeline,
@@ -36,12 +37,12 @@ impl<'a> Participant<'a> {
     }
 
     /// Borrow the underlying component for this participant.
-    pub fn component(&self) -> &component::Component<'_> {
+    pub fn component(&self) -> &Component<'_> {
         &self.component
     }
 
     /// Borrow the positioned lifeline drawable.
-    pub fn lifeline(&self) -> &draw::PositionedDrawable<draw::Lifeline> {
+    pub fn lifeline(&self) -> &PositionedDrawable<Lifeline> {
         &self.lifeline
     }
 }
@@ -69,7 +70,7 @@ impl<'a> Participant<'a> {
 pub struct ActivationBox {
     participant_id: Id,
     center_y: f32,
-    drawable: draw::ActivationBox,
+    drawable: DrawActivationBox,
 }
 
 /// An activation period with precise timing information during processing.
@@ -89,7 +90,7 @@ pub struct ActivationTiming {
     participant_id: Id,
     start_y: f32,
     nesting_level: u32,
-    definition: Rc<draw::ActivationBoxDefinition>,
+    definition: Rc<ActivationBoxDefinition>,
 }
 
 impl ActivationTiming {
@@ -98,7 +99,7 @@ impl ActivationTiming {
         participant_id: Id,
         start_y: f32,
         nesting_level: u32,
-        definition: Rc<draw::ActivationBoxDefinition>,
+        definition: Rc<ActivationBoxDefinition>,
     ) -> Self {
         Self {
             participant_id,
@@ -121,7 +122,7 @@ impl ActivationTiming {
         let center_y = (self.start_y() + end_y) / 2.0;
         let height = end_y - self.start_y();
         let drawable =
-            draw::ActivationBox::new(Rc::clone(&self.definition), height, self.nesting_level());
+            DrawActivationBox::new(Rc::clone(&self.definition), height, self.nesting_level());
 
         ActivationBox {
             participant_id: self.participant_id(),
@@ -158,7 +159,7 @@ impl ActivationBox {
     }
 
     /// Returns a reference to the drawable activation box
-    pub fn drawable(&self) -> &draw::ActivationBox {
+    pub fn drawable(&self) -> &DrawActivationBox {
         &self.drawable
     }
 
@@ -199,7 +200,7 @@ impl ActivationBox {
 ///
 /// This struct accumulates information about a fragment as it's being processed during
 /// layout calculation, including its vertical position, horizontal bounds, and sections.
-/// It's converted to a [`Fragment`](draw::Fragment) once processing is complete.
+/// It's converted to a [`Fragment`](DrawFragment) once processing is complete.
 ///
 /// # Fields
 /// - `start_y`: The Y coordinate where this fragment begins
@@ -212,14 +213,14 @@ pub struct FragmentTiming<'a> {
     start_y: f32,
     min_x: f32,
     max_x: f32,
-    fragment: &'a semantic::Fragment,
-    active_section: Option<(&'a semantic::FragmentSection, f32)>,
-    sections: Vec<draw::FragmentSection>,
+    fragment: &'a Fragment,
+    active_section: Option<(&'a FragmentSection, f32)>,
+    sections: Vec<DrawFragmentSection>,
 }
 
 impl<'a> FragmentTiming<'a> {
     /// Creates a new `FragmentTiming` for the given fragment starting at the specified Y position.
-    pub fn new(fragment: &'a semantic::Fragment, start_y: f32) -> Self {
+    pub fn new(fragment: &'a Fragment, start_y: f32) -> Self {
         Self {
             start_y,
             min_x: f32::MAX,
@@ -234,7 +235,7 @@ impl<'a> FragmentTiming<'a> {
     ///
     /// # Panics
     /// Panics in debug builds if there's already an active section.
-    pub fn start_section(&mut self, section: &'a semantic::FragmentSection, start_y: f32) {
+    pub fn start_section(&mut self, section: &'a FragmentSection, start_y: f32) {
         #[cfg(debug_assertions)]
         assert!(self.active_section.is_none());
 
@@ -251,7 +252,7 @@ impl<'a> FragmentTiming<'a> {
             .active_section
             .take()
             .ok_or("There is no active fragment section")?;
-        let section = draw::FragmentSection::new(
+        let section = DrawFragmentSection::new(
             ast_section.title().map(|title| title.to_string()),
             end_y - start_y,
         );
@@ -281,7 +282,7 @@ impl<'a> FragmentTiming<'a> {
     /// # Arguments
     ///
     /// * `section` - The semantic fragment section to measure.
-    pub fn section_header_height(&self, section: &semantic::FragmentSection) -> f32 {
+    pub fn section_header_height(&self, section: &FragmentSection) -> f32 {
         let definition = self.fragment.definition();
         let section_header_height = definition.section_header_size(section.title()).height();
 
@@ -311,11 +312,11 @@ impl<'a> FragmentTiming<'a> {
     ///
     /// # Returns
     /// A positioned `Fragment` ready for rendering
-    pub fn into_fragment(self, end_y: f32) -> draw::PositionedDrawable<draw::Fragment> {
+    pub fn into_fragment(self, end_y: f32) -> PositionedDrawable<DrawFragment> {
         #[cfg(debug_assertions)]
         assert!(self.active_section.is_none());
 
-        let drawable = draw::Fragment::new(
+        let drawable = DrawFragment::new(
             Rc::clone(self.fragment.definition()),
             self.fragment.operation().to_string(),
             self.sections,
@@ -327,7 +328,7 @@ impl<'a> FragmentTiming<'a> {
         let center_y = (self.start_y + end_y) / 2.0;
         let position = Point::new(center_x, center_y);
 
-        draw::PositionedDrawable::new(drawable).with_position(position)
+        PositionedDrawable::new(drawable).with_position(position)
     }
 }
 
@@ -399,7 +400,7 @@ pub fn find_active_activation_box_for_participant(
 /// The X coordinate where the message should connect to this participant
 pub fn calculate_message_endpoint_x(
     activation_boxes: &[ActivationBox],
-    participant: &component::Component,
+    participant: &Component,
     participant_id: Id,
     message_y: f32,
     target_x: f32,
@@ -417,10 +418,10 @@ pub fn calculate_message_endpoint_x(
 #[derive(Debug, Clone)]
 pub struct Layout<'a> {
     participants: HashMap<Id, Participant<'a>>,
-    messages: Vec<draw::PositionedArrowWithText<'a>>,
+    messages: Vec<PositionedArrowWithText<'a>>,
     activations: Vec<ActivationBox>,
-    fragments: Vec<draw::PositionedDrawable<draw::Fragment>>,
-    notes: Vec<draw::PositionedDrawable<draw::Note>>,
+    fragments: Vec<PositionedDrawable<DrawFragment>>,
+    notes: Vec<PositionedDrawable<Note>>,
     max_lifeline_end: f32, // TODO: Consider calculating on the fly.
     bounds: Bounds,
 }
@@ -429,10 +430,10 @@ impl<'a> Layout<'a> {
     /// Construct a new sequence layout.
     pub fn new(
         participants: HashMap<Id, Participant<'a>>,
-        messages: Vec<draw::PositionedArrowWithText<'a>>,
+        messages: Vec<PositionedArrowWithText<'a>>,
         activations: Vec<ActivationBox>,
-        fragments: Vec<draw::PositionedDrawable<draw::Fragment>>,
-        notes: Vec<draw::PositionedDrawable<draw::Note>>,
+        fragments: Vec<PositionedDrawable<DrawFragment>>,
+        notes: Vec<PositionedDrawable<Note>>,
         max_lifeline_end: f32,
     ) -> Self {
         let bounds = participants
@@ -459,7 +460,7 @@ impl<'a> Layout<'a> {
     }
 
     /// Borrow all messages in this sequence layout.
-    pub fn messages(&self) -> &[draw::PositionedArrowWithText<'a>] {
+    pub fn messages(&self) -> &[PositionedArrowWithText<'a>] {
         &self.messages
     }
 
@@ -469,12 +470,12 @@ impl<'a> Layout<'a> {
     }
 
     /// Borrow all fragments in this sequence layout.
-    pub fn fragments(&self) -> &[draw::PositionedDrawable<draw::Fragment>] {
+    pub fn fragments(&self) -> &[PositionedDrawable<DrawFragment>] {
         &self.fragments
     }
 
     /// Borrow all notes in this sequence layout.
-    pub fn notes(&self) -> &[draw::PositionedDrawable<draw::Note>] {
+    pub fn notes(&self) -> &[PositionedDrawable<Note>] {
         &self.notes
     }
 
@@ -492,14 +493,15 @@ impl<'a> LayoutBounds for Layout<'a> {
 
 #[cfg(test)]
 mod tests {
+    use orrery_core::draw::{Drawable, FragmentDefinition};
+
     use super::*;
-    use orrery_core::draw::Drawable;
 
     #[test]
     fn test_activation_box_is_active_at_y() {
         // Create a test activation box with center_y=100.0 and height=20.0
-        let definition = draw::ActivationBoxDefinition::default();
-        let drawable = draw::ActivationBox::new(Rc::new(definition), 20.0, 0);
+        let definition = ActivationBoxDefinition::default();
+        let drawable = DrawActivationBox::new(Rc::new(definition), 20.0, 0);
         let activation_box = ActivationBox {
             participant_id: Id::new("test"),
             center_y: 100.0,
@@ -519,8 +521,8 @@ mod tests {
     #[test]
     fn test_activation_box_get_intersection_x() {
         // Create a test activation box with nesting level 0
-        let definition = draw::ActivationBoxDefinition::default();
-        let drawable = draw::ActivationBox::new(Rc::new(definition), 20.0, 0);
+        let definition = ActivationBoxDefinition::default();
+        let drawable = DrawActivationBox::new(Rc::new(definition), 20.0, 0);
         let activation_box = ActivationBox {
             participant_id: Id::new("test"),
             center_y: 100.0,
@@ -541,8 +543,8 @@ mod tests {
     #[test]
     fn test_activation_box_nesting_offset() {
         // Test activation box with nesting level 2
-        let definition = draw::ActivationBoxDefinition::default();
-        let drawable = draw::ActivationBox::new(Rc::new(definition), 20.0, 2);
+        let definition = ActivationBoxDefinition::default();
+        let drawable = DrawActivationBox::new(Rc::new(definition), 20.0, 2);
         let activation_box = ActivationBox {
             participant_id: Id::new("test"),
             center_y: 100.0,
@@ -564,7 +566,7 @@ mod tests {
 
         // Activation box 1: participant 0, Y range [90-110], nesting level 0
         let drawable1 =
-            draw::ActivationBox::new(Rc::new(draw::ActivationBoxDefinition::default()), 20.0, 0);
+            DrawActivationBox::new(Rc::new(ActivationBoxDefinition::default()), 20.0, 0);
         let activation_box1 = ActivationBox {
             participant_id: Id::new("test"),
             center_y: 100.0,
@@ -573,7 +575,7 @@ mod tests {
 
         // Activation box 2: participant 0, Y range [95-105], nesting level 1 (nested)
         let drawable2 =
-            draw::ActivationBox::new(Rc::new(draw::ActivationBoxDefinition::default()), 10.0, 1);
+            DrawActivationBox::new(Rc::new(ActivationBoxDefinition::default()), 10.0, 1);
         let activation_box2 = ActivationBox {
             participant_id: Id::new("test"),
             center_y: 100.0,
@@ -582,7 +584,7 @@ mod tests {
 
         // Activation box 3: participant 1, Y range [120-140], nesting level 0
         let drawable3 =
-            draw::ActivationBox::new(Rc::new(draw::ActivationBoxDefinition::default()), 20.0, 0);
+            DrawActivationBox::new(Rc::new(ActivationBoxDefinition::default()), 20.0, 0);
         let activation_box3 = ActivationBox {
             participant_id: Id::new("test"),
             center_y: 130.0,
@@ -632,8 +634,8 @@ mod tests {
         // Test with multiple boxes at different nesting levels
         let boxes: Vec<ActivationBox> = (0..5)
             .map(|i| {
-                let definition = draw::ActivationBoxDefinition::default();
-                let drawable = draw::ActivationBox::new(Rc::new(definition), 20.0, i);
+                let definition = ActivationBoxDefinition::default();
+                let drawable = DrawActivationBox::new(Rc::new(definition), 20.0, i);
                 ActivationBox {
                     participant_id: Id::new("test"),
                     center_y: 100.0,
@@ -651,8 +653,8 @@ mod tests {
     #[test]
     fn test_find_active_activation_box_error_handling() {
         // Create a test activation box for error handling tests
-        let definition = draw::ActivationBoxDefinition::default();
-        let drawable = draw::ActivationBox::new(Rc::new(definition), 20.0, 0);
+        let definition = ActivationBoxDefinition::default();
+        let drawable = DrawActivationBox::new(Rc::new(definition), 20.0, 0);
         let activation_box = ActivationBox {
             participant_id: Id::new("test"),
             center_y: 100.0,
@@ -699,8 +701,8 @@ mod tests {
         assert!(result.is_none());
 
         // Test with activation boxes for different participant (should fallback)
-        let definition = draw::ActivationBoxDefinition::default();
-        let drawable = draw::ActivationBox::new(Rc::new(definition), 20.0, 0);
+        let definition = ActivationBoxDefinition::default();
+        let drawable = DrawActivationBox::new(Rc::new(definition), 20.0, 0);
         let activation_box = ActivationBox {
             participant_id: Id::new("test_1"), // Different participant
             center_y: 100.0,
@@ -720,14 +722,13 @@ mod tests {
 
     #[test]
     fn test_fragment_timing_lifecycle() {
-        // Create a mock semantic::Fragment for testing
-        let fragment_def = Rc::new(draw::FragmentDefinition::default());
+        // Create a mock Fragment for testing
+        let fragment_def = Rc::new(FragmentDefinition::default());
 
-        let section1 = semantic::FragmentSection::new(Some("section 1".to_string()), vec![]);
-        let section2 = semantic::FragmentSection::new(Some("section 2".to_string()), vec![]);
+        let section1 = FragmentSection::new(Some("section 1".to_string()), vec![]);
+        let section2 = FragmentSection::new(Some("section 2".to_string()), vec![]);
 
-        let fragment =
-            semantic::Fragment::new("alt".to_string(), vec![section1, section2], fragment_def);
+        let fragment = Fragment::new("alt".to_string(), vec![section1, section2], fragment_def);
 
         // Create FragmentTiming
         let start_y = 100.0;
@@ -761,10 +762,10 @@ mod tests {
 
     #[test]
     fn test_fragment_timing_bounds_tracking() {
-        // Create a mock semantic::Fragment
-        let fragment_def = Rc::new(draw::FragmentDefinition::default());
+        // Create a mock Fragment
+        let fragment_def = Rc::new(FragmentDefinition::default());
 
-        let fragment = semantic::Fragment::new("opt".to_string(), vec![], fragment_def);
+        let fragment = Fragment::new("opt".to_string(), vec![], fragment_def);
 
         let mut fragment_timing = FragmentTiming::new(&fragment, 100.0);
 
@@ -796,10 +797,9 @@ mod tests {
     #[test]
     fn test_section_header_height_first_section_header_dominates() {
         // Use a short section title so the fragment header (pentagon) is taller.
-        let fragment_def = Rc::new(draw::FragmentDefinition::default());
-        let section = semantic::FragmentSection::new(Some("x".to_string()), vec![]);
-        let fragment =
-            semantic::Fragment::new("alt".to_string(), vec![section], fragment_def.clone());
+        let fragment_def = Rc::new(FragmentDefinition::default());
+        let section = FragmentSection::new(Some("x".to_string()), vec![]);
+        let fragment = Fragment::new("alt".to_string(), vec![section], fragment_def.clone());
 
         let fragment_timing = FragmentTiming::new(&fragment, 0.0);
 
@@ -812,11 +812,10 @@ mod tests {
     #[test]
     fn test_section_header_height_first_section_title_dominates() {
         // Use a multi-line section title so the title is taller than the header.
-        let fragment_def = Rc::new(draw::FragmentDefinition::default());
+        let fragment_def = Rc::new(FragmentDefinition::default());
         let tall_title = "line1\nline2\nline3\nline4\nline5";
-        let section = semantic::FragmentSection::new(Some(tall_title.to_string()), vec![]);
-        let fragment =
-            semantic::Fragment::new("alt".to_string(), vec![section], fragment_def.clone());
+        let section = FragmentSection::new(Some(tall_title.to_string()), vec![]);
+        let fragment = Fragment::new("alt".to_string(), vec![section], fragment_def.clone());
 
         let fragment_timing = FragmentTiming::new(&fragment, 0.0);
 
@@ -828,10 +827,10 @@ mod tests {
 
     #[test]
     fn test_section_header_height_subsequent_section() {
-        let fragment_def = Rc::new(draw::FragmentDefinition::default());
-        let section1 = semantic::FragmentSection::new(Some("guard1".to_string()), vec![]);
-        let section2 = semantic::FragmentSection::new(Some("guard2".to_string()), vec![]);
-        let fragment = semantic::Fragment::new(
+        let fragment_def = Rc::new(FragmentDefinition::default());
+        let section1 = FragmentSection::new(Some("guard1".to_string()), vec![]);
+        let section2 = FragmentSection::new(Some("guard2".to_string()), vec![]);
+        let fragment = Fragment::new(
             "alt".to_string(),
             vec![section1, section2],
             fragment_def.clone(),
@@ -852,10 +851,9 @@ mod tests {
 
     #[test]
     fn test_section_header_height_no_title() {
-        let fragment_def = Rc::new(draw::FragmentDefinition::default());
-        let section = semantic::FragmentSection::new(None, vec![]);
-        let fragment =
-            semantic::Fragment::new("opt".to_string(), vec![section], fragment_def.clone());
+        let fragment_def = Rc::new(FragmentDefinition::default());
+        let section = FragmentSection::new(None, vec![]);
+        let fragment = Fragment::new("opt".to_string(), vec![section], fragment_def.clone());
 
         let mut fragment_timing = FragmentTiming::new(&fragment, 0.0);
 
@@ -864,7 +862,7 @@ mod tests {
         fragment_timing.end_section(50.0).unwrap();
 
         // Subsequent section with no title: height should be 0.
-        let no_title_section = semantic::FragmentSection::new(None, vec![]);
+        let no_title_section = FragmentSection::new(None, vec![]);
         let height = fragment_timing.section_header_height(&no_title_section);
 
         assert_eq!(height, 0.0);
@@ -872,11 +870,11 @@ mod tests {
 
     #[test]
     fn test_bottom_padding_delegates_to_definition() {
-        let mut fragment_def = draw::FragmentDefinition::default();
+        let mut fragment_def = FragmentDefinition::default();
         fragment_def.set_bounds_padding(orrery_core::geometry::Insets::new(5.0, 10.0, 15.0, 20.0));
         let fragment_def = Rc::new(fragment_def);
 
-        let fragment = semantic::Fragment::new("loop".to_string(), vec![], fragment_def);
+        let fragment = Fragment::new("loop".to_string(), vec![], fragment_def);
 
         let fragment_timing = FragmentTiming::new(&fragment, 0.0);
 

--- a/crates/orrery/src/lib.rs
+++ b/crates/orrery/src/lib.rs
@@ -11,13 +11,11 @@ mod layout;
 mod structure;
 
 pub use orrery_core::{color, draw, identifier, semantic};
-pub use orrery_parser::error::ParseError;
+pub use orrery_parser::{InMemorySourceProvider, SourceProvider, error::ParseError};
 
 pub use error::RenderError;
 
 use std::{fs, path::Path};
-
-pub use orrery_parser::{InMemorySourceProvider, SourceProvider};
 
 use bumpalo::Bump;
 use log::{debug, info, trace};

--- a/crates/orrery/src/structure.rs
+++ b/crates/orrery/src/structure.rs
@@ -19,7 +19,10 @@ pub use sequence::{SequenceEvent, SequenceGraph};
 
 use log::trace;
 
-use orrery_core::{identifier::Id, semantic};
+use orrery_core::{
+    identifier::Id,
+    semantic::{Diagram, DiagramKind, Element},
+};
 
 use crate::RenderError;
 
@@ -49,7 +52,7 @@ impl<'a, 'idx> GraphKind<'a, 'idx> {
     /// - The constructed [`GraphKind::ComponentGraph`] variant
     /// - A vector of [`HierarchyNode`] representing any embedded diagrams found
     fn build_component(
-        elements: &'a [semantic::Element],
+        elements: &'a [Element],
     ) -> Result<(Self, Vec<HierarchyNode<'a, 'idx>>), RenderError> {
         let (graph, children) = ComponentGraph::new_from_elements(elements)?;
         Ok((Self::ComponentGraph(graph), children))
@@ -68,7 +71,7 @@ impl<'a, 'idx> GraphKind<'a, 'idx> {
     /// - The constructed [`GraphKind::SequenceGraph`] variant
     /// - A vector of [`HierarchyNode`] representing any embedded diagrams found
     fn build_sequence(
-        elements: &'a [semantic::Element],
+        elements: &'a [Element],
     ) -> Result<(Self, Vec<HierarchyNode<'a, 'idx>>), RenderError> {
         let (graph, children) = SequenceGraph::new_from_elements(elements)?;
         Ok((Self::SequenceGraph(graph), children))
@@ -78,13 +81,13 @@ impl<'a, 'idx> GraphKind<'a, 'idx> {
 /// Container that pairs an AST diagram with its graph representation.
 #[derive(Debug)]
 pub struct GraphedDiagram<'a, 'idx> {
-    ast_diagram: &'a semantic::Diagram,
+    ast_diagram: &'a Diagram,
     graph_kind: GraphKind<'a, 'idx>,
 }
 
 impl<'a, 'idx> GraphedDiagram<'a, 'idx> {
     /// Returns a reference to the underlying AST diagram.
-    pub fn ast_diagram(&self) -> &semantic::Diagram {
+    pub fn ast_diagram(&self) -> &Diagram {
         self.ast_diagram
     }
 
@@ -97,7 +100,7 @@ impl<'a, 'idx> GraphedDiagram<'a, 'idx> {
     }
 
     /// Creates a new graphed diagram from an AST diagram and its graph representation.
-    fn new(ast_diagram: &'a semantic::Diagram, graph_kind: GraphKind<'a, 'idx>) -> Self {
+    fn new(ast_diagram: &'a Diagram, graph_kind: GraphKind<'a, 'idx>) -> Self {
         Self {
             ast_diagram,
             graph_kind,
@@ -154,16 +157,12 @@ impl<'a, 'idx> HierarchyNode<'a, 'idx> {
     /// A constructed `HierarchyNode` with its graph and children, or an error if
     /// graph construction fails.
     fn build_from_ast_diagram(
-        ast_diagram: &'a semantic::Diagram,
+        ast_diagram: &'a Diagram,
         container_id: Option<Id>,
     ) -> Result<Self, RenderError> {
         let (graph, children) = match ast_diagram.kind() {
-            semantic::DiagramKind::Component => {
-                GraphKind::build_component(ast_diagram.scope().elements())?
-            }
-            semantic::DiagramKind::Sequence => {
-                GraphKind::build_sequence(ast_diagram.scope().elements())?
-            }
+            DiagramKind::Component => GraphKind::build_component(ast_diagram.scope().elements())?,
+            DiagramKind::Sequence => GraphKind::build_sequence(ast_diagram.scope().elements())?,
         };
         let graphed_diagram = GraphedDiagram::new(ast_diagram, graph);
 
@@ -211,7 +210,7 @@ impl<'a, 'idx> DiagramHierarchy<'a, 'idx> {
     ///
     /// A [`DiagramHierarchy`] containing the graph representations of all diagrams
     /// in the hierarchy, or an [`RenderError`] if graph construction fails.
-    pub fn from_diagram(diagram: &'a semantic::Diagram) -> Result<Self, RenderError> {
+    pub fn from_diagram(diagram: &'a Diagram) -> Result<Self, RenderError> {
         // Process all elements in the diagram recursively
         let root_diagram = HierarchyNode::build_from_ast_diagram(diagram, None)?;
 

--- a/crates/orrery/src/structure/component.rs
+++ b/crates/orrery/src/structure/component.rs
@@ -21,7 +21,10 @@
 
 use log::debug;
 
-use orrery_core::{identifier::Id, semantic};
+use orrery_core::{
+    identifier::Id,
+    semantic::{Block, Element, Node, Relation},
+};
 
 use super::{
     HierarchyNode,
@@ -74,7 +77,7 @@ impl<'a, 'idx> ContainmentScope<'a, 'idx> {
     }
 
     /// Adds a component node to this containment scope.
-    fn add_node(&mut self, node: &semantic::Node) {
+    fn add_node(&mut self, node: &Node) {
         let id = node.id();
         self.graph.add_node(id, id);
     }
@@ -119,7 +122,7 @@ impl<'a, 'idx> ContainmentScope<'a, 'idx> {
     /// A vector of `HierarchyNode`s representing any embedded diagrams found during processing.
     fn populate_component_graph(
         graph: &mut ComponentGraph<'a, '_>,
-        elements: &'a [semantic::Element],
+        elements: &'a [Element],
         container: Option<Id>,
     ) -> Result<Vec<HierarchyNode<'a, 'idx>>, RenderError> {
         let mut child_diagrams = vec![];
@@ -128,12 +131,12 @@ impl<'a, 'idx> ContainmentScope<'a, 'idx> {
 
         // First pass: add all nodes to the graph
         for element in elements {
-            if let semantic::Element::Node(node) = element {
+            if let Element::Node(node) = element {
                 graph.add_node(&mut containment_scope, node);
 
                 // Process the node's inner block recursively
                 match node.block() {
-                    semantic::Block::Scope(scope) => {
+                    Block::Scope(scope) => {
                         debug!(
                             "Processing nested scope with {} elements",
                             scope.elements().len()
@@ -145,7 +148,7 @@ impl<'a, 'idx> ContainmentScope<'a, 'idx> {
                         )?;
                         child_diagrams.append(&mut inner_child_diagrams);
                     }
-                    semantic::Block::Diagram(inner_diagram) => {
+                    Block::Diagram(inner_diagram) => {
                         debug!(
                             "Processing nested diagram of kind {:?}",
                             inner_diagram.kind()
@@ -154,7 +157,7 @@ impl<'a, 'idx> ContainmentScope<'a, 'idx> {
                             HierarchyNode::build_from_ast_diagram(inner_diagram, Some(node.id()))?;
                         child_diagrams.push(inner_hierarchy_child);
                     }
-                    semantic::Block::None => {}
+                    Block::None => {}
                 }
             }
         }
@@ -162,14 +165,14 @@ impl<'a, 'idx> ContainmentScope<'a, 'idx> {
         // Second pass: add all relations and activation statements to the graph
         for element in elements {
             match element {
-                semantic::Element::Relation(relation) => {
+                Element::Relation(relation) => {
                     graph.add_relation(&mut containment_scope, relation);
                 }
-                semantic::Element::Node(..) => {}
-                semantic::Element::Activate(..)
-                | semantic::Element::Deactivate(..)
-                | semantic::Element::Fragment(..)
-                | semantic::Element::Note(..) => {
+                Element::Node(..) => {}
+                Element::Activate(..)
+                | Element::Deactivate(..)
+                | Element::Fragment(..)
+                | Element::Note(..) => {
                     unreachable!("Unexpected element type")
                 }
             }
@@ -193,13 +196,13 @@ impl<'a, 'idx> ContainmentScope<'a, 'idx> {
 /// 2. Containment scopes that organize nodes by their hierarchical level
 #[derive(Debug)]
 pub struct ComponentGraph<'a, 'idx> {
-    graph: GraphInternal<'idx, &'a semantic::Node, &'a semantic::Relation>,
+    graph: GraphInternal<'idx, &'a Node, &'a Relation>,
     containment_scopes: Vec<ContainmentScope<'a, 'idx>>,
 }
 
 impl<'a, 'idx> ComponentGraph<'a, 'idx> {
     /// Returns the AST node for a component with the given ID, if it exists.
-    pub fn node_by_id(&self, id: Id) -> Option<&semantic::Node> {
+    pub fn node_by_id(&self, id: Id) -> Option<&Node> {
         self.graph.node(id)
     }
 
@@ -214,10 +217,7 @@ impl<'a, 'idx> ComponentGraph<'a, 'idx> {
     ///
     /// This provides access to the AST nodes for all components at a particular
     /// hierarchical level in the diagram.
-    pub fn scope_nodes(
-        &self,
-        containment_scope: &ContainmentScope,
-    ) -> impl Iterator<Item = &semantic::Node> {
+    pub fn scope_nodes(&self, containment_scope: &ContainmentScope) -> impl Iterator<Item = &Node> {
         containment_scope
             .node_ids()
             .map(|id| self.graph.node_unchecked(id))
@@ -230,7 +230,7 @@ impl<'a, 'idx> ComponentGraph<'a, 'idx> {
     pub fn scope_relations(
         &self,
         containment_scope: &ContainmentScope,
-    ) -> impl Iterator<Item = &semantic::Relation> {
+    ) -> impl Iterator<Item = &Relation> {
         containment_scope
             .relation_indices()
             .map(|idx| self.graph.edge_unchecked(idx))
@@ -240,10 +240,7 @@ impl<'a, 'idx> ComponentGraph<'a, 'idx> {
     ///
     /// Root nodes are components that have no incoming relations within the scope,
     /// typically representing top-level components in the hierarchy.
-    pub fn scope_roots(
-        &self,
-        containment_scope: &ContainmentScope,
-    ) -> impl Iterator<Item = &semantic::Node> {
+    pub fn scope_roots(&self, containment_scope: &ContainmentScope) -> impl Iterator<Item = &Node> {
         containment_scope
             .root_ids()
             .map(|id| self.graph.node_unchecked(id))
@@ -257,7 +254,7 @@ impl<'a, 'idx> ComponentGraph<'a, 'idx> {
         &self,
         containment_scope: &ContainmentScope,
         source_id: Id,
-    ) -> impl Iterator<Item = &semantic::Node> {
+    ) -> impl Iterator<Item = &Node> {
         containment_scope
             .outgoing_node_ids(source_id)
             .map(|id| self.graph.node_unchecked(id))
@@ -268,7 +265,7 @@ impl<'a, 'idx> ComponentGraph<'a, 'idx> {
     /// Processes the elements to build the graph structure and identify any
     /// embedded diagrams that need separate processing.
     pub(super) fn new_from_elements(
-        elements: &'a [semantic::Element],
+        elements: &'a [Element],
     ) -> Result<(Self, Vec<HierarchyNode<'a, 'idx>>), RenderError> {
         let mut graph = Self::new();
         let children = ContainmentScope::populate_component_graph(&mut graph, elements, None)?;
@@ -284,11 +281,7 @@ impl<'a, 'idx> ComponentGraph<'a, 'idx> {
     }
 
     /// Adds a component node to the graph and its containment scope.
-    fn add_node(
-        &mut self,
-        containment_scope: &mut ContainmentScope<'a, 'idx>,
-        node: &'a semantic::Node,
-    ) {
+    fn add_node(&mut self, containment_scope: &mut ContainmentScope<'a, 'idx>, node: &'a Node) {
         self.graph.add_node(node.id(), node);
         containment_scope.add_node(node);
     }
@@ -302,7 +295,7 @@ impl<'a, 'idx> ComponentGraph<'a, 'idx> {
     fn add_relation(
         &mut self,
         containment_scope: &mut ContainmentScope<'a, 'idx>,
-        relation: &'a semantic::Relation,
+        relation: &'a Relation,
     ) {
         let source_id = relation.source();
         let target_id = relation.target();

--- a/crates/orrery/src/structure/sequence.rs
+++ b/crates/orrery/src/structure/sequence.rs
@@ -18,7 +18,10 @@
 use indexmap::IndexMap;
 use log::debug;
 
-use orrery_core::{identifier::Id, semantic};
+use orrery_core::{
+    identifier::Id,
+    semantic::{Activate, Block, Element, Fragment, FragmentSection, Node, Note, Relation},
+};
 
 use crate::RenderError;
 
@@ -43,14 +46,14 @@ pub enum SequenceEvent<'a> {
     ///
     /// Contains a reference to the AST relation which includes source, target,
     /// and any label or styling information.
-    Relation(&'a semantic::Relation),
+    Relation(&'a Relation),
 
     /// Start of an activation period for a participant.
     ///
     /// Activation represents a period when a participant has focus of control,
     /// typically shown as a white rectangle on the participant's lifeline.
     /// Contains a reference to the AST activate which includes participant ID and styling.
-    Activate(&'a semantic::Activate),
+    Activate(&'a Activate),
 
     /// End of an activation period for a participant.
     ///
@@ -62,13 +65,13 @@ pub enum SequenceEvent<'a> {
     ///
     /// Fragments group related interactions with an operation type (e.g., "alt", "loop").
     /// This event marks the beginning of a fragment's scope.
-    FragmentStart(&'a semantic::Fragment),
+    FragmentStart(&'a Fragment),
 
     /// Start of a section within a fragment.
     ///
     /// Sections divide a fragment into parts (e.g., different cases in an "alt" fragment).
     /// Each section may have an optional title describing its condition or purpose.
-    FragmentSectionStart(&'a semantic::FragmentSection),
+    FragmentSectionStart(&'a FragmentSection),
 
     /// End of a section within a fragment.
     ///
@@ -84,7 +87,7 @@ pub enum SequenceEvent<'a> {
     ///
     /// Notes provide additional context or documentation without participating
     /// in the diagram's structural relationships.
-    Note(&'a semantic::Note),
+    Note(&'a Note),
 }
 
 /// Main graph structure for sequence diagrams.
@@ -95,7 +98,7 @@ pub enum SequenceEvent<'a> {
 /// which is critical for correct temporal visualization in sequence diagrams.
 #[derive(Debug)]
 pub struct SequenceGraph<'a> {
-    nodes: IndexMap<Id, &'a semantic::Node>,
+    nodes: IndexMap<Id, &'a Node>,
     events: Vec<SequenceEvent<'a>>,
 }
 
@@ -118,8 +121,8 @@ impl<'a> SequenceGraph<'a> {
     /// without activation/deactivation events.
     ///
     /// # Returns
-    /// An iterator yielding [`semantic::Relation`] items for message events only, in temporal order.
-    pub fn relations(&self) -> impl Iterator<Item = &semantic::Relation> {
+    /// An iterator yielding [`Relation`] items for message events only, in temporal order.
+    pub fn relations(&self) -> impl Iterator<Item = &Relation> {
         self.events().filter_map(|event| match event {
             SequenceEvent::Relation(relation) => Some(*relation),
             _ => None,
@@ -127,7 +130,7 @@ impl<'a> SequenceGraph<'a> {
     }
 
     /// Returns an iterator over all participant nodes in the sequence diagram.
-    pub fn nodes(&self) -> impl Iterator<Item = &semantic::Node> {
+    pub fn nodes(&self) -> impl Iterator<Item = &Node> {
         self.nodes.values().cloned()
     }
 
@@ -146,7 +149,7 @@ impl<'a> SequenceGraph<'a> {
     /// A tuple containing the constructed sequence graph and a vector of any embedded
     /// diagrams found during processing.
     pub(super) fn new_from_elements<'idx>(
-        elements: &'a [semantic::Element],
+        elements: &'a [Element],
     ) -> Result<(Self, Vec<super::HierarchyNode<'a, 'idx>>), RenderError> {
         let mut graph = Self::new();
 
@@ -167,7 +170,7 @@ impl<'a> SequenceGraph<'a> {
     ///
     /// Registers the participant in the graph's node map, making it available
     /// for use in relations and activation events.
-    fn add_node(&mut self, node: &'a semantic::Node) {
+    fn add_node(&mut self, node: &'a Node) {
         self.nodes.insert(node.id(), node);
     }
 
@@ -184,18 +187,18 @@ impl<'a> SequenceGraph<'a> {
     /// This helper method processes elements, adding events to the graph and returning
     /// any child diagrams found.
     fn process_elements<'idx>(
-        elements: &'a [semantic::Element],
+        elements: &'a [Element],
         graph: &mut SequenceGraph<'a>,
     ) -> Result<Vec<super::HierarchyNode<'a, 'idx>>, RenderError> {
         let mut child_diagrams = Vec::new();
         for element in elements {
             match element {
-                semantic::Element::Node(node) => {
+                Element::Node(node) => {
                     graph.add_node(node);
 
                     // Process the node's inner block recursively
                     match node.block() {
-                        semantic::Block::Diagram(inner_diagram) => {
+                        Block::Diagram(inner_diagram) => {
                             debug!(
                                 "Processing nested diagram of kind {:?}",
                                 inner_diagram.kind()
@@ -207,22 +210,22 @@ impl<'a> SequenceGraph<'a> {
                                 )?;
                             child_diagrams.push(inner_hierarchy_child);
                         }
-                        semantic::Block::None => {}
-                        semantic::Block::Scope(..) => {
+                        Block::None => {}
+                        Block::Scope(..) => {
                             unreachable!("Unexpected scope block in sequence diagram")
                         }
                     }
                 }
-                semantic::Element::Relation(relation) => {
+                Element::Relation(relation) => {
                     graph.add_event(SequenceEvent::Relation(relation));
                 }
-                semantic::Element::Activate(activate) => {
+                Element::Activate(activate) => {
                     graph.add_event(SequenceEvent::Activate(activate));
                 }
-                semantic::Element::Deactivate(id) => {
+                Element::Deactivate(id) => {
                     graph.add_event(SequenceEvent::Deactivate(*id));
                 }
-                semantic::Element::Fragment(fragment) => {
+                Element::Fragment(fragment) => {
                     // Emit FragmentStart event
                     graph.add_event(SequenceEvent::FragmentStart(fragment));
 
@@ -243,7 +246,7 @@ impl<'a> SequenceGraph<'a> {
                     // Emit FragmentEnd event
                     graph.add_event(SequenceEvent::FragmentEnd);
                 }
-                semantic::Element::Note(note) => {
+                Element::Note(note) => {
                     graph.add_event(SequenceEvent::Note(note));
                 }
             }
@@ -255,20 +258,16 @@ impl<'a> SequenceGraph<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::rc::Rc;
 
-    use orrery_core::{
-        draw,
-        semantic::{Block, Node},
-    };
+    use orrery_core::draw::{RectangleDefinition, ShapeDefinition};
+
+    use super::*;
 
     /// Helper function to create a minimal mock node for testing
     fn create_test_node(id_str: &str) -> Node {
         let id = Id::new(id_str);
-        let shape_def =
-            Rc::new(Box::new(draw::RectangleDefinition::new()) as Box<dyn draw::ShapeDefinition>);
+        let shape_def = Rc::new(Box::new(RectangleDefinition::new()) as Box<dyn ShapeDefinition>);
 
         Node::new(id, None, Block::None, shape_def)
     }

--- a/crates/orrery/tests/builder_api_test.rs
+++ b/crates/orrery/tests/builder_api_test.rs
@@ -5,6 +5,7 @@
 use std::path::Path;
 
 use bumpalo::Bump;
+
 use orrery::{DiagramBuilder, InMemorySourceProvider, config::AppConfig};
 
 #[test]


### PR DESCRIPTION
## Summary

Replace verbose `module::Type` qualified paths with direct imports throughout the workspace. Reorder module declarations before use statements in shape.rs per style conventions.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A
