### PR TITLE
refactor(layout): derive participant ID in endpoint_x calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Simplified qualified import paths across workspace** — Replaced verbose `module::Type` qualified paths with direct imports, reordered module declarations before use statements per style conventions. ([#129](https://github.com/orreryworks/orrery/pull/129))
+- **Simplified `calculate_message_endpoint_x` signature** — Removed the redundant `participant_id` parameter; the function now derives it internally from the participant component. ([#130](https://github.com/orreryworks/orrery/pull/130))
 
 ## [0.4.0] - 2026-05-23
 

--- a/crates/orrery/src/layout/engines/basic/sequence.rs
+++ b/crates/orrery/src/layout/engines/basic/sequence.rs
@@ -485,14 +485,12 @@ impl Engine {
         let source_x = sequence::calculate_message_endpoint_x(
             activations,
             source_participant,
-            msg.source(),
             msg.y_position(),
             target_participant.position().x(),
         );
         let target_x = sequence::calculate_message_endpoint_x(
             activations,
             target_participant,
-            msg.target(),
             msg.y_position(),
             source_participant.position().x(),
         );
@@ -561,7 +559,6 @@ impl Engine {
         let x_anchor = sequence::calculate_message_endpoint_x(
             activations,
             participant,
-            msg.source(),
             msg.y_position(),
             f32::INFINITY,
         );

--- a/crates/orrery/src/layout/sequence.rs
+++ b/crates/orrery/src/layout/sequence.rs
@@ -332,26 +332,10 @@ impl<'a> FragmentTiming<'a> {
     }
 }
 
-/// Find the active activation box for a given participant at a specific Y coordinate.
+/// Finds the most-nested active [`ActivationBox`] for a participant at a given Y coordinate.
 ///
-/// This function searches through all activation boxes to find ones that:
-/// 1. Belong to the specified participant (by participant_index)
-/// 2. Are active at the given Y coordinate (message_y falls within their vertical range)
-///
-/// If multiple activation boxes are nested and active at the same Y coordinate,
-/// returns the most nested one (highest nesting level) to ensure messages connect
-/// to the outermost active activation box.
-///
-/// # Arguments
-///
-/// * `activation_boxes` - Slice of all activation boxes in the sequence diagram
-/// * `participant_index` - Index of the participant to search for (0-based)
-/// * `message_y` - Y coordinate where the message appears
-///
-/// # Returns
-///
-/// * `Some(&ActivationBox)` - Reference to the most nested active activation box
-/// * `None` - If no activation boxes are active for this participant at this Y coordinate
+/// When multiple nested boxes are active at `message_y`, returns the deepest one
+/// so messages attach to the innermost active scope.
 pub fn find_active_activation_box_for_participant(
     activation_boxes: &[ActivationBox],
     participant_id: Id,
@@ -380,34 +364,28 @@ pub fn find_active_activation_box_for_participant(
     active_boxes.last().copied()
 }
 
-/// Calculate the X coordinate for a message endpoint, considering activation box intersections.
+/// Calculates the X coordinate where a message connects to a participant.
 ///
-/// This function encapsulates the logic for determining where a message should start or end
-/// by checking if there's an active activation box at the message Y coordinate. If an active
-/// activation box is found, it calculates the appropriate edge intersection. Otherwise, it
-/// falls back to using the participant's center X coordinate.
+/// If an active [`ActivationBox`] exists at `message_y`, returns the box edge
+/// facing `target_x`; otherwise falls back to the participant's center X.
 ///
 /// # Arguments
 ///
-/// * `activation_boxes` - Slice of all activation boxes in the sequence diagram
-/// * `participant` - The participant component for this endpoint
-/// * `participant_index` - Index of the participant (0-based)
-/// * `message_y` - Y coordinate where the message appears
-/// * `target_x` - X coordinate of the target endpoint (used for direction detection)
-///
-/// # Returns
-///
-/// The X coordinate where the message should connect to this participant
+/// * `activation_boxes` - All activation boxes in the diagram.
+/// * `participant` - The participant at this endpoint.
+/// * `message_y` - Y coordinate of the message line.
+/// * `target_x` - X of the opposite endpoint; used only for direction detection.
 pub fn calculate_message_endpoint_x(
     activation_boxes: &[ActivationBox],
     participant: &Component,
-    participant_id: Id,
     message_y: f32,
     target_x: f32,
 ) -> f32 {
-    if let Some(activation_box) =
-        find_active_activation_box_for_participant(activation_boxes, participant_id, message_y)
-    {
+    if let Some(activation_box) = find_active_activation_box_for_participant(
+        activation_boxes,
+        participant.node_id(),
+        message_y,
+    ) {
         activation_box.intersection_x(participant.position(), target_x)
     } else {
         participant.position().x()


### PR DESCRIPTION
## Summary

Remove the redundant `participant_id` parameter — the function now obtains it from `participant.node_id()`, eliminating the need for callers to pass it separately.

Also tighten doc comments on `calculate_message_endpoint_x` and `find_active_activation_box_for_participant`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A
