### PR TITLE
fix(draw): avoid double padding on text background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Simplified `calculate_message_endpoint_x` signature** — Removed the redundant `participant_id` parameter; the function now derives it internally from the participant component. ([#130](https://github.com/orreryworks/orrery/pull/130))
 - **Sequence message endpoints use activation snapshots** — Messages capture each side's active `ActivationTiming` at event time and compute endpoint X from the snapshot, replacing the Y-range scan over activation boxes. ([#132](https://github.com/orreryworks/orrery/pull/132))
 
+### Fixed
+
+- **Text label background no longer double-padded** — The configured padding was applied twice, leaving the background visibly larger than the text it wraps. ([#133](https://github.com/orreryworks/orrery/pull/133))
+
 ## [0.4.0] - 2026-05-23
 
 ### Added

--- a/crates/orrery-core/src/draw/text.rs
+++ b/crates/orrery-core/src/draw/text.rs
@@ -279,7 +279,6 @@ impl<'a> Drawable for Text<'a> {
     fn render_to_layers(&self, position: Point) -> LayeredOutput {
         let mut output = LayeredOutput::new();
         let text_size = self.calculate_size();
-        let padding = self.definition.padding();
 
         let lines: Vec<&str> = self.content.lines().collect();
 
@@ -319,7 +318,7 @@ impl<'a> Drawable for Text<'a> {
 
         // Add background rectangle if color is specified
         if let Some(bg_color) = self.definition.background_color() {
-            let bg_bounds = position.to_bounds(text_size).add_padding(padding);
+            let bg_bounds = position.to_bounds(text_size);
             let bg_size = bg_bounds.to_size();
             let bg_min_point = bg_bounds.min_point();
 


### PR DESCRIPTION
## Summary

`Text::render_to_layers` was building the background rectangle bounds from `text_size` (which already includes the configured padding via `Text::calculate_size`) and then applying `Bounds::add_padding(padding)` a second time. The result was a background sized `text + 2 × padding` instead of `text + padding`, so any non-zero padding made the rectangle visibly wider and taller than the text it wraps.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A
