### PR TITLE
fix(draw): detect inner content via explicit flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Text label background no longer double-padded** — The configured padding was applied twice, leaving the background visibly larger than the text it wraps. ([#133](https://github.com/orreryworks/orrery/pull/133))
+- **Narrow shape labels now correctly identified as having no inner content** — Previously they were treated as embedded content, pushing the text to the top of the shape instead of its center. ([#134](https://github.com/orreryworks/orrery/pull/134))
 
 ## [0.4.0] - 2026-05-23
 

--- a/crates/orrery-core/src/draw/shape_with_text.rs
+++ b/crates/orrery-core/src/draw/shape_with_text.rs
@@ -130,7 +130,7 @@ impl<'a> ShapeWithText<'a> {
 
         let shape_size = self.shape.inner_size();
         let text_size = self.text_size();
-        let has_inner_content = text_size != self.shape.content_size();
+        let has_inner_content = self.inner_content_size.is_some_and(|s| !s.is_zero());
 
         self.text_positioning_strategy.calculate_text_position(
             total_position,


### PR DESCRIPTION
## Summary

`ShapeWithText::calculate_text_position` inferred "has inner content" by comparing `text_size` to `shape.content_size()`. That comparison spuriously fired when a shape's `min_content_size` clamped `content_size` above the text dimensions — for example a single narrow character in a Rectangle whose `min_content_size` is 10x10 — so the text-positioning strategy skipped top padding and pinned the label to the top edge of the shape instead of centering it inside.

`ShapeWithText` already tracks the real signal in `inner_content_size`, which is set only when the layout attaches embedded content via `set_inner_content_size`. The fix uses that flag directly, so narrow-label shapes (e.g. single-glyph participant boxes) center their text correctly. No call sites change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A
