### PR TITLE
fix(draw): render font-size in points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Text label background no longer double-padded** — The configured padding was applied twice, leaving the background visibly larger than the text it wraps. ([#133](https://github.com/orreryworks/orrery/pull/133))
 - **Narrow shape labels now correctly identified as having no inner content** — Previously they were treated as embedded content, pushing the text to the top of the shape instead of its center. ([#134](https://github.com/orreryworks/orrery/pull/134))
+- **Font sizes now rendered in points** — Glyphs were drawn about 25% smaller than the configured size, leaving label backgrounds visibly larger than the rendered text. Default sizes were lowered to preserve the previous visual sizing. ([#135](https://github.com/orreryworks/orrery/pull/135))
 
 ## [0.4.0] - 2026-05-23
 

--- a/crates/orrery-core/src/draw/fragment.rs
+++ b/crates/orrery-core/src/draw/fragment.rs
@@ -231,13 +231,13 @@ impl Default for FragmentDefinition {
     fn default() -> Self {
         // Create default text definition for operation label
         let mut operation_label_text_definition = TextDefinition::new();
-        operation_label_text_definition.set_font_size(12);
+        operation_label_text_definition.set_font_size(9);
         operation_label_text_definition.set_color(Some(Color::default()));
         operation_label_text_definition.set_padding(Insets::new(4.0, 8.0, 4.0, 8.0));
 
         // Create default text definition for section titles
         let mut section_title_text_definition = TextDefinition::new();
-        section_title_text_definition.set_font_size(11);
+        section_title_text_definition.set_font_size(8);
         section_title_text_definition
             .set_color(Some(Color::new("#666666").expect("Invalid color")));
         section_title_text_definition.set_padding(Insets::new(2.0, 4.0, 2.0, 20.0));

--- a/crates/orrery-core/src/draw/text.rs
+++ b/crates/orrery-core/src/draw/text.rs
@@ -74,7 +74,7 @@ static DEFAULT_TEXT: OnceLock<TextDefinition> = OnceLock::new();
 /// | Property | Default |
 /// |----------|---------|
 /// | Font family | `"Arial"` |
-/// | Font size | `15` |
+/// | Font size | `11` |
 /// | Background color | `None` |
 /// | Text color | `None` (SVG default, typically black) |
 /// | Padding | Zero on all sides |
@@ -104,15 +104,12 @@ pub struct TextDefinition {
 impl TextDefinition {
     /// Returns a reference to the default text definition (borrowed from static).
     ///
-    /// - Font family: "sans-serif"
-    /// - Font size: 12
-    /// - Background color: None
-    /// - Text color: None
-    /// - Padding: 4px on all sides
+    /// Differs from [`Self::default`] in font family (`sans-serif`), font
+    /// size (`9`), and 4 px uniform padding.
     pub fn default_borrowed() -> &'static Self {
         DEFAULT_TEXT.get_or_init(|| TextDefinition {
             font_family: String::from("sans-serif"),
-            font_size: 12,
+            font_size: 9,
             background_color: None,
             color: None,
             padding: Insets::uniform(4.0),
@@ -183,6 +180,13 @@ impl TextDefinition {
         self.font_size
     }
 
+    /// Returns the font size in CSS pixels (1 pt = 96/72 px at 96 dpi).
+    ///
+    /// The size is stored in points (see [`Self::set_font_size`]).
+    fn font_size_px(&self) -> f32 {
+        f32::from(self.font_size) * (96.0 / 72.0)
+    }
+
     fn font_family(&self) -> &str {
         &self.font_family
     }
@@ -206,7 +210,7 @@ impl TextDefinition {
 impl Default for TextDefinition {
     fn default() -> Self {
         Self {
-            font_size: 15,
+            font_size: 11,
             background_color: None,
             color: None,
             padding: Insets::default(),
@@ -299,7 +303,7 @@ impl<'a> Drawable for Text<'a> {
             .set("text-anchor", "middle")
             .set("dominant-baseline", "central")
             .set("font-family", self.definition.font_family())
-            .set("font-size", self.definition.font_size());
+            .set("font-size", format!("{}pt", self.definition.font_size()));
 
         // Set text color if specified
         if let Some(color) = self.definition.color() {
@@ -364,19 +368,14 @@ impl TextManager {
         }
     }
 
-    /// Calculate the actual size of text in pixels using cosmic-text.
+    /// Measures the actual size of text in pixels.
     ///
     /// This provides an accurate measurement based on real font metrics and shaping,
     /// including proper handling of ligatures, kerning, and other advanced typography features.
     ///
-    /// # Arguments
-    ///
-    /// * `text` - The text content to measure
-    /// * `text_def` - Text definition containing font family, size, and other styling
-    ///
     /// # Returns
     ///
-    /// The calculated size in pixels, or default size if measurement fails
+    /// The calculated size in pixels, or [`Size::zero`] for empty input.
     fn calculate_text_size(&self, text: &str, text_def: &TextDefinition) -> Size {
         if text.is_empty() {
             return Size::zero();
@@ -385,8 +384,7 @@ impl TextManager {
         // Lock the FontSystem for use
         let mut font_system = self.font_system.lock().expect("failed to lock FontSystem");
 
-        // Convert font size from points to pixels (roughly 1.33x multiplier for standard DPI)
-        let font_size_px = text_def.font_size() as f32 * 1.33;
+        let font_size_px = text_def.font_size_px();
 
         // Create metrics with font size and approximate line height
         let line_height = font_size_px * 1.15;
@@ -458,7 +456,7 @@ mod tests {
     fn test_text_definition_default_borrowed_values() {
         let borrowed = TextDefinition::default_borrowed();
         // Static default has different values than Default trait
-        assert_eq!(borrowed.font_size(), 12);
+        assert_eq!(borrowed.font_size(), 9);
         assert_eq!(borrowed.font_family(), "sans-serif");
         assert!(borrowed.background_color().is_none());
         assert!(borrowed.color().is_none());
@@ -472,7 +470,7 @@ mod tests {
     #[test]
     fn test_text_definition_set_font_size() {
         let mut def = TextDefinition::new();
-        assert_eq!(def.font_size(), 15); // default
+        assert_eq!(def.font_size(), 11); // default
 
         def.set_font_size(24);
         assert_eq!(def.font_size(), 24);


### PR DESCRIPTION
## Summary

`TextDefinition::font_size` is in points, but `Text::render_to_layers` emitted it as a unitless SVG `font-size` attribute that the renderer resolved as user units (≈ pixels). Glyphs drew at ~75% of the requested size, while the measurement side correctly converted points to pixels — so label backgrounds came out visibly wider and taller than the rendered text.

The fix has two parts:

- Emit `font-size="<N>pt"` from `Text::render_to_layers` so the renderer uses points. A new `TextDefinition::font_size_px` exposes the pt→px conversion at the measurement site (no behavior change there).
- Lower the default font sizes, since they were calibrated against the under-sized rendering and would over-shoot once points are used end-to-end:
  - `TextDefinition::default`: 15 → 11
  - `TextDefinition::default_borrowed`: 12 → 9
  - `FragmentDefinition::default`: operation 12 → 9, section title 11 → 8

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A
