### PR TITLE
refactor(layout): move arrow routing from SVG export into engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Arrow routing moved from SVG export into layout engines** — Engines now compute path geometry and produce control points; the core draw layer only renders them. A new `SmartArrowPlacer` routes each relation by its `style`. ([#137](https://github.com/orreryworks/orrery/pull/137))
 - **Simplified qualified import paths across workspace** — Replaced verbose `module::Type` qualified paths with direct imports, reordered module declarations before use statements per style conventions. ([#129](https://github.com/orreryworks/orrery/pull/129))
 - **Simplified `calculate_message_endpoint_x` signature** — Removed the redundant `participant_id` parameter; the function now derives it internally from the participant component. ([#130](https://github.com/orreryworks/orrery/pull/130))
 - **Sequence message endpoints use activation snapshots** — Messages capture each side's active `ActivationTiming` at event time and compute endpoint X from the snapshot, replacing the Y-range scan over activation boxes. ([#132](https://github.com/orreryworks/orrery/pull/132))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cfcded997a93eb31edd639361fa33fd229a8784e953b37d71035fe3890b7b"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "env_filter"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +840,7 @@ dependencies = [
  "float-cmp",
  "graphviz-rust",
  "indexmap",
+ "itertools",
  "layout-rs",
  "log",
  "orrery-core",
@@ -863,6 +879,7 @@ dependencies = [
  "color",
  "cosmic-text",
  "float-cmp",
+ "itertools",
  "log",
  "proptest",
  "serde",

--- a/crates/orrery-core/Cargo.toml
+++ b/crates/orrery-core/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "2.0.18"
 cosmic-text = "0.17.0"
 log = { version = "0.4.30", features = ["kv", "kv_std"] }
 serde = { version = "1.0", features = ["derive"] }
+itertools = "0.14.0"
 
 [dev-dependencies]
 float-cmp = "0.10"

--- a/crates/orrery-core/src/draw/arrow.rs
+++ b/crates/orrery-core/src/draw/arrow.rs
@@ -3,8 +3,9 @@
 //! This module provides types for defining and rendering arrows in diagrams,
 //! including stroke styling, path shapes, direction markers, and SVG output.
 
-use std::{collections::HashMap, fmt, rc::Rc, str::FromStr};
+use std::{collections::HashMap, fmt, iter, rc::Rc, str::FromStr};
 
+use itertools::Itertools;
 use svg::{self, node::element as svg_element};
 
 use crate::{
@@ -20,7 +21,7 @@ use crate::{
 /// - `Straight`: Creates direct line segments between points
 /// - `Curved`: Creates smooth bezier curves between points
 /// - `Orthogonal`: Creates only horizontal and vertical line segments
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ArrowStyle {
     Straight,
     #[default]
@@ -325,8 +326,7 @@ impl Arrow {
     fn render_to_svg(&self, path: &ArrowPath) -> Box<dyn svg::Node> {
         let path_data = match self.definition.style {
             ArrowStyle::Curved => Self::curved_path_data(path),
-            ArrowStyle::Straight => Self::straight_path_data(path.source(), path.destination()),
-            ArrowStyle::Orthogonal => Self::orthogonal_path_data(path.source(), path.destination()),
+            ArrowStyle::Straight | ArrowStyle::Orthogonal => Self::polyline_path_data(path),
         };
 
         let color = self.definition.stroke().color();
@@ -381,7 +381,7 @@ impl Arrow {
 
     /// Creates an SVG path data string for an [`ArrowPath`].
     ///
-    /// Returns a straight line via [`Self::straight_path_data`] when
+    /// Returns a straight line via [`Self::polyline_path_data`] when
     /// [`control_points`](ArrowPath::control_points) is empty. Otherwise,
     /// control points are consumed from the front in cubic Bézier groups
     /// of three, and the tail is resolved based on how many remain:
@@ -406,7 +406,7 @@ impl Arrow {
     /// An SVG path data string (`d` attribute) for a `<path>` element.
     fn curved_path_data(path: &ArrowPath) -> String {
         if path.control_points().is_empty() {
-            return Self::straight_path_data(path.source(), path.destination());
+            return Self::polyline_path_data(path);
         }
 
         let control_points = path.control_points();
@@ -479,47 +479,38 @@ impl Arrow {
         d
     }
 
-    /// Creates a straight-line path data string from two points.
-    pub fn straight_path_data(start: Point, end: Point) -> String {
-        format!("M {} {} L {} {}", start.x(), start.y(), end.x(), end.y())
-    }
-
-    /// Creates an orthogonal path data string from two points.
+    /// Creates a polyline path data string from an [`ArrowPath`].
     ///
-    /// Produces a path with only horizontal and vertical line segments.
-    fn orthogonal_path_data(start: Point, end: Point) -> String {
-        // Determine whether to go horizontal first then vertical, or vertical first then horizontal
-        // This decision is based on the relative positions of the start and end points
+    /// The path runs from [`source`](ArrowPath::source) through each
+    /// [`control point`](ArrowPath::control_points) to
+    /// [`destination`](ArrowPath::destination) as straight `L` segments. With
+    /// no control points this is a single straight line; with them it produces
+    /// a multi-segment polyline.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use orrery_core::draw::{Arrow, ArrowPath};
+    /// # use orrery_core::geometry::Point;
+    /// // A right-angle route turning at a single corner.
+    /// let path = ArrowPath::new(
+    ///     Point::new(0.0, 0.0),
+    ///     Point::new(10.0, 10.0),
+    ///     vec![Point::new(10.0, 0.0)],
+    /// );
+    /// assert_eq!(Arrow::polyline_path_data(&path), "M 0 0 L 10 0 L 10 10");
+    /// ```
+    pub fn polyline_path_data(path: &ArrowPath) -> String {
+        let l_parts = path
+            .control_points()
+            .iter()
+            .copied()
+            .chain(iter::once(path.destination()))
+            .map(|p| format!("L {} {}", p.x(), p.y()));
 
-        let abs_dist = end.sub_point(start).abs();
-        let mid = start.midpoint(end);
-
-        // If we're more horizontal than vertical, go horizontal first
-        if abs_dist.x() > abs_dist.y() {
-            format!(
-                "M {} {} L {} {} L {} {} L {} {}",
-                start.x(),
-                start.y(),
-                mid.x(),
-                start.y(),
-                mid.x(),
-                end.y(),
-                end.x(),
-                end.y()
-            )
-        } else {
-            format!(
-                "M {} {} L {} {} L {} {} L {} {}",
-                start.x(),
-                start.y(),
-                start.x(),
-                mid.y(),
-                end.x(),
-                mid.y(),
-                end.x(),
-                end.y()
-            )
-        }
+        iter::once(format!("M {} {}", path.source().x(), path.source().y()))
+            .chain(l_parts)
+            .join(" ")
     }
 
     fn create_arrow_right(color: Color) -> svg_element::Marker {
@@ -662,13 +653,26 @@ mod tests {
     }
 
     #[test]
-    fn test_straight_path_data() {
-        let start = Point::new(10.0, 20.0);
-        let end = Point::new(100.0, 50.0);
+    fn test_polyline_path_data_without_control_points() {
+        let path = ArrowPath::straight(Point::new(10.0, 20.0), Point::new(100.0, 50.0));
 
-        let path = Arrow::straight_path_data(start, end);
+        let path = Arrow::polyline_path_data(&path);
 
         assert_eq!(path, "M 10 20 L 100 50");
+    }
+
+    #[test]
+    fn test_polyline_path_data_with_control_points() {
+        // Control points produce additional `L` segments (e.g. orthogonal routing).
+        let path = ArrowPath::new(
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 20.0),
+            vec![Point::new(50.0, 0.0), Point::new(50.0, 20.0)],
+        );
+
+        let data = Arrow::polyline_path_data(&path);
+
+        assert_eq!(data, "M 0 0 L 50 0 L 50 20 L 100 20");
     }
 
     #[test]

--- a/crates/orrery-core/src/draw/arrow_with_text.rs
+++ b/crates/orrery-core/src/draw/arrow_with_text.rs
@@ -212,6 +212,11 @@ impl<'a> PositionedArrowWithText<'a> {
         self
     }
 
+    /// Returns the geometric path of this arrow.
+    pub fn path(&self) -> &ArrowPath {
+        &self.path
+    }
+
     /// Renders this positioned arrow to layered SVG output.
     ///
     /// # Arguments

--- a/crates/orrery/Cargo.toml
+++ b/crates/orrery/Cargo.toml
@@ -39,6 +39,7 @@ tempfile = "3.27.0"
 graphviz-rust = { version = "0.9.8", optional = true }
 dot-structures = { version = "0.1.2", optional = true }
 dot-generator = { version = "0.2.0", optional = true }
+itertools = "0.14.0"
 
 [dev-dependencies]
 float-cmp = "0.10"

--- a/crates/orrery/src/layout/component.rs
+++ b/crates/orrery/src/layout/component.rs
@@ -7,11 +7,13 @@
 
 use std::{collections::HashMap, rc::Rc};
 
+use itertools::Itertools;
 use log::{debug, error};
 
 use orrery_core::{
     draw::{
-        Arrow, ArrowPath, ArrowWithText, PositionedArrowWithText, PositionedDrawable, ShapeWithText,
+        Arrow, ArrowPath, ArrowStyle, ArrowWithText, PositionedArrowWithText, PositionedDrawable,
+        ShapeWithText,
     },
     geometry::{Bounds, Point},
     identifier::Id,
@@ -97,7 +99,7 @@ impl<'a> Component<'a> {
 ///   self-loop buckets the same [`Component`] is passed for both.
 /// - Relations within the bucket may go either direction; inspect
 ///   [`Relation::source`](semantic::Relation::source) to determine orientation.
-/// - Return exactly one arrow per input relation, in the same order.
+/// - Return exactly one arrow per input relation.
 pub trait ArrowPlacer {
     /// Places a bucket of relations between the same component pair.
     fn place<'a>(
@@ -352,6 +354,119 @@ impl ArrowPlacer for CurvedArrowPlacer {
     }
 }
 
+/// [`ArrowPlacer`] that routes every relation as an orthogonal path made of
+/// horizontal and vertical segments.
+///
+/// Each path turns once at the midpoint, going horizontal-first when the pair
+/// is wider than it is tall and vertical-first otherwise. Like
+/// [`StraightArrowPlacer`], parallel/reverse relations overlap into a single
+/// path; it does not offset them onto separate lanes.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OrthogonalArrowPlacer;
+
+impl OrthogonalArrowPlacer {
+    /// Builds the right-angle [`ArrowPath`] between two boundary points.
+    fn path(source: Point, target: Point) -> ArrowPath {
+        let abs_dist = target.sub_point(source).abs();
+        let mid = source.midpoint(target);
+
+        let cps = if abs_dist.x() > abs_dist.y() {
+            vec![mid.with_y(source.y()), mid.with_y(target.y())]
+        } else {
+            vec![mid.with_x(source.x()), mid.with_x(target.x())]
+        };
+        ArrowPath::new(source, target, cps)
+    }
+
+    /// Orthogonal arrow from `source` boundary to `target` boundary.
+    fn place_one<'a>(
+        relation: &'a Relation,
+        source: &Component<'_>,
+        target: &Component<'_>,
+    ) -> PositionedArrowWithText<'a> {
+        let arrow_def = Rc::clone(relation.arrow_definition());
+        let arrow = Arrow::new(arrow_def, relation.arrow_direction());
+        let arrow_with_text = ArrowWithText::new(arrow, relation.text());
+
+        let source_edge = source.find_intersection(target.position());
+        let target_edge = target.find_intersection(source.position());
+        let path = Self::path(source_edge, target_edge);
+
+        PositionedArrowWithText::new(arrow_with_text, path)
+    }
+}
+
+impl ArrowPlacer for OrthogonalArrowPlacer {
+    fn place<'a>(
+        &self,
+        relations: &[&'a Relation],
+        source: &Component<'_>,
+        target: &Component<'_>,
+    ) -> Vec<PositionedArrowWithText<'a>> {
+        relations
+            .iter()
+            .map(|relation| {
+                let (rel_src, rel_tgt) = align_to_relation(relation, source, target);
+                Self::place_one(relation, rel_src, rel_tgt)
+            })
+            .collect()
+    }
+}
+
+/// [`ArrowPlacer`] that dispatches each relation to a concrete placer based on
+/// its [`ArrowStyle`].
+///
+/// Non-self-loop relations are grouped by style and routed by
+/// [`StraightArrowPlacer`], [`CurvedArrowPlacer`], or [`OrthogonalArrowPlacer`]
+/// accordingly. Self-loops are always routed by [`CurvedArrowPlacer`]
+/// regardless of style.
+///
+/// # Known limitations
+///
+/// Because relations are grouped by style before routing, each delegate only
+/// sees the relations of its own style. [`CurvedArrowPlacer`] therefore lanes
+/// parallel edges only within the curved subset, so mixed-style parallel edges
+/// between the same pair may overlap. Output order is not preserved across
+/// style groups.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SmartArrowPlacer {
+    straight: StraightArrowPlacer,
+    curved: CurvedArrowPlacer,
+    orthogonal: OrthogonalArrowPlacer,
+}
+
+impl SmartArrowPlacer {
+    /// Creates a new `SmartArrowPlacer` with default delegate placers.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ArrowPlacer for SmartArrowPlacer {
+    fn place<'a>(
+        &self,
+        relations: &[&'a Relation],
+        source: &Component<'_>,
+        target: &Component<'_>,
+    ) -> Vec<PositionedArrowWithText<'a>> {
+        if source.node_id() == target.node_id() {
+            return self.curved.place(relations, source, target);
+        }
+        let grouped = relations
+            .iter()
+            .copied()
+            .into_group_map_by(|r| r.arrow_definition().style());
+        grouped
+            .into_iter()
+            .flat_map(|(style, relations)| match style {
+                ArrowStyle::Straight => self.straight.place(&relations, source, target),
+                ArrowStyle::Curved => self.curved.place(&relations, source, target),
+                ArrowStyle::Orthogonal => self.orthogonal.place(&relations, source, target),
+            })
+            .collect()
+    }
+}
+
 /// A complete layout of components and their relationships.
 ///
 /// A `Layout` contains all the positioned components and their connecting relations
@@ -552,6 +667,18 @@ mod tests {
             ArrowDirection::Forward,
             None,
             Rc::new(ArrowDefinition::default()),
+        )
+    }
+
+    fn make_relation_with_style(source: Id, target: Id, style: ArrowStyle) -> Relation {
+        let mut arrow_def = ArrowDefinition::default();
+        arrow_def.set_style(style);
+        Relation::new(
+            source,
+            target,
+            ArrowDirection::Forward,
+            None,
+            Rc::new(arrow_def),
         )
     }
 
@@ -798,5 +925,77 @@ mod tests {
         let r5 = make_relation(a.node_id(), a.node_id());
         let out_self = router.place(&[&r4, &r5], &a, &a);
         assert_eq!(out_self.len(), 2);
+    }
+
+    #[test]
+    fn orthogonal_path_horizontal_first_when_wider() {
+        let source = Point::new(0.0, 0.0);
+        let target = Point::new(100.0, 20.0);
+        let path = OrthogonalArrowPlacer::path(source, target);
+
+        let cps = path.control_points();
+        assert_eq!(cps.len(), 2);
+        assert_point_approx_eq(cps[0], Point::new(50.0, 0.0));
+        assert_point_approx_eq(cps[1], Point::new(50.0, 20.0));
+    }
+
+    #[test]
+    fn orthogonal_path_vertical_first_when_taller() {
+        let source = Point::new(0.0, 0.0);
+        let target = Point::new(20.0, 100.0);
+        let path = OrthogonalArrowPlacer::path(source, target);
+
+        let cps = path.control_points();
+        assert_eq!(cps.len(), 2);
+        assert_point_approx_eq(cps[0], Point::new(0.0, 50.0));
+        assert_point_approx_eq(cps[1], Point::new(20.0, 50.0));
+    }
+
+    #[test]
+    fn orthogonal_place_produces_one_arrow_per_relation() {
+        let a_node = make_node("a");
+        let b_node = make_node("b");
+        let a = make_component(&a_node, Point::new(0.0, 0.0));
+        let b = make_component(&b_node, Point::new(100.0, 0.0));
+        let r1 = make_relation(a.node_id(), b.node_id());
+        let r2 = make_relation(b.node_id(), a.node_id());
+
+        let out = OrthogonalArrowPlacer.place(&[&r1, &r2], &a, &b);
+        assert_eq!(out.len(), 2);
+        // Orthogonal arrows carry two control points each.
+        for arrow in &out {
+            assert_eq!(arrow.path().control_points().len(), 2);
+        }
+    }
+
+    #[test]
+    fn smart_place_returns_one_arrow_per_relation_for_mixed_styles() {
+        let a_node = make_node("a");
+        let b_node = make_node("b");
+        let a = make_component(&a_node, Point::new(0.0, 0.0));
+        let b = make_component(&b_node, Point::new(100.0, 0.0));
+        let r_straight = make_relation_with_style(a.node_id(), b.node_id(), ArrowStyle::Straight);
+        let r_curved = make_relation_with_style(a.node_id(), b.node_id(), ArrowStyle::Curved);
+        let r_orthogonal =
+            make_relation_with_style(a.node_id(), b.node_id(), ArrowStyle::Orthogonal);
+
+        let placer = SmartArrowPlacer::new();
+        let out = placer.place(&[&r_straight, &r_curved, &r_orthogonal], &a, &b);
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn smart_place_routes_self_loops_through_curved_placer() {
+        let a_node = make_node("a");
+        let a = make_component(&a_node, Point::new(50.0, 50.0));
+        // Even an orthogonal-styled self-loop must be routed as a curve.
+        let r = make_relation_with_style(a.node_id(), a.node_id(), ArrowStyle::Orthogonal);
+
+        let placer = SmartArrowPlacer::new();
+        let out = placer.place(&[&r], &a, &a);
+        assert_eq!(out.len(), 1);
+        // Curved self-loops are cubic Béziers (two control points) and carry a
+        // label position override, unlike the orthogonal placer.
+        assert_eq!(out[0].path().control_points().len(), 2);
     }
 }

--- a/crates/orrery/src/layout/engines/basic/component.rs
+++ b/crates/orrery/src/layout/engines/basic/component.rs
@@ -18,7 +18,7 @@ use orrery_core::{
 use crate::{
     error::RenderError,
     layout::{
-        component::{self, ArrowPlacer, Component, CurvedArrowPlacer, Layout},
+        component::{self, ArrowPlacer, Component, Layout, SmartArrowPlacer},
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -39,7 +39,7 @@ pub struct Engine {
     text_padding: f32,
     /// Minimum spacing between adjacent components.
     min_spacing: f32,
-    arrow_placer: CurvedArrowPlacer,
+    arrow_placer: SmartArrowPlacer,
 }
 
 impl Engine {

--- a/crates/orrery/src/layout/engines/sugiyama/component.rs
+++ b/crates/orrery/src/layout/engines/sugiyama/component.rs
@@ -15,7 +15,7 @@ use orrery_core::{
 use crate::{
     error::RenderError,
     layout::{
-        component::{self, ArrowPlacer, Component, CurvedArrowPlacer, Layout},
+        component::{self, ArrowPlacer, Component, Layout, SmartArrowPlacer},
         engines::{ComponentEngine, EmbeddedLayouts},
         layer::{ContentStack, PositionedContent},
     },
@@ -36,7 +36,7 @@ pub struct Engine {
     vertical_spacing: f32,
     /// Container padding for nested components.
     container_padding: Insets,
-    arrow_placer: CurvedArrowPlacer,
+    arrow_placer: SmartArrowPlacer,
 }
 
 impl Engine {
@@ -47,7 +47,7 @@ impl Engine {
             horizontal_spacing: 50.0,
             vertical_spacing: 80.0,
             container_padding: Insets::uniform(20.0),
-            arrow_placer: CurvedArrowPlacer::new(),
+            arrow_placer: SmartArrowPlacer::new(),
         }
     }
 


### PR DESCRIPTION
Arrow path geometry was previously computed in the core draw/SVG export layer: Arrow::orthogonal_path_data decided where to turn at render time, so routing decisions were baked into rendering. Move that responsibility into the layout engines, which now own routing and produce the ArrowPath control points; the core draw layer only renders the points it is given.

Collapse Arrow::straight_path_data and orthogonal_path_data into a single
Arrow::polyline_path_data that walks an ArrowPath's control points, so core no longer makes routing decisions for any style.

Add OrthogonalArrowPlacer, which performs the right-angle routing that used to live in core (turn once at the midpoint, horizontal-first when wider, vertical-first when taller). Add SmartArrowPlacer to dispatch each
relation to the straight, curved, or orthogonal placer by its ArrowStyle,
keeping self-loops curved. Wire SmartArrowPlacer into the basic and sugiyama engines so the relation `style` attribute is honored.

Expose PositionedArrowWithText::path, add itertools, and derive Hash for ArrowStyle.

## Summary

Arrow path geometry used to be computed in the core `draw`/SVG export layer, so
routing decisions were baked into rendering. This PR moves that responsibility
into the layout engines, which now own routing and produce the `ArrowPath`
control points; the core `draw` layer only renders the points it is given.

Key changes:

- Collapse `Arrow::straight_path_data` and `orthogonal_path_data` into a single
  `Arrow::polyline_path_data` that walks an `ArrowPath`'s control points.
- Add `OrthogonalArrowPlacer`, performing the right-angle routing that used to
  live in core.
- Add `SmartArrowPlacer` to dispatch each relation to the straight, curved, or
  orthogonal placer by its `ArrowStyle`.
- Wire `SmartArrowPlacer` into the basic and sugiyama engines.
- Expose `PositionedArrowWithText::path`, add `itertools`, and derive `Hash` for
  `ArrowStyle`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Other: <!-- describe -->

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/orreryworks/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`cargo test --workspace`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Documentation updated (if applicable)

## Related Issues

N/A
